### PR TITLE
Add dispatch_index_earliest and dispatch_index_latest arguments for saved searches

### DIFF
--- a/client/models/saved_searches.go
+++ b/client/models/saved_searches.go
@@ -105,6 +105,8 @@ type SavedSearchObject struct {
 	Disabled                           bool    `json:"disabled" url:"disabled"`
 	DispatchBuckets                    int     `json:"dispatch.buckets,omitempty" url:"dispatch.buckets,omitempty"`
 	DispatchEarliestTime               string  `json:"dispatch.earliest_time,omitempty" url:"dispatch.earliest_time,omitempty"`
+	DispatchIndexEarliest              string  `json:"dispatch.index_earliest,omitempty" url:"dispatch.index_earliest,omitempty"`
+	DispatchIndexLatest                string  `json:"dispatch.index_latest,omitempty" url:"dispatch.index_latest,omitempty"`
 	DispatchIndexedRealtime            bool    `json:"dispatch.indexedRealtime" url:"dispatch.indexedRealtime"`
 	DispatchIndexedRealtimeOffset      int     `json:"dispatch.indexedRealtimeOffset" url:"dispatch.indexedRealtimeOffset,omitempty"`
 	DispatchIndexedRealtimeMinspan     int     `json:"dispatch.indexedRealtimeMinspan" url:"dispatch.indexedRealtimeMinspan,omitempty"`

--- a/docs/resources/saved_searches.md
+++ b/docs/resources/saved_searches.md
@@ -10,10 +10,10 @@ resource "splunk_saved_searches" "saved_search" {
     action_email_format = "table"
     action_email_max_time = "5m"
     action_email_max_results = 10
-	action_email_send_results = false
-	action_email_subject = "Splunk Alert: $name$"
-	action_email_to = "splunk@splunk.com"
-	action_email_track_alert = true
+    action_email_send_results = false
+    action_email_subject = "Splunk Alert: $name$"
+    action_email_to = "splunk@splunk.com"
+    action_email_track_alert = true
     dispatch_earliest_time = "rt-15m"
     dispatch_latest_time = "rt-0m"
     cron_schedule = "*/5 * * * *"
@@ -123,8 +123,10 @@ This resource block supports the following arguments:
 * `description` - (Optional) Human-readable description of this saved search. Defaults to empty string.
 * `disabled` - (Optional) Indicates if the saved search is enabled. Defaults to 0.Disabled saved searches are not visible in Splunk Web.
 * `dispatch_buckets` - (Optional) The maximum number of timeline buckets. Defaults to 0.
-* `dispatch_earliest_time` - (Optional) A time string that specifies the earliest time for this search. Can be a relative or absolute time.If this value is an absolute time, use the dispatch.time_format to format the value.
-* `dispatch_indexed_realtime` - (Optional) A time string that specifies the earliest time for this search. Can be a relative or absolute time.If this value is an absolute time, use the dispatch.time_format to format the value.
+* `dispatch_earliest_time` - (Optional) A time string that specifies the earliest time for this search. Can be a relative or absolute time. If this value is an absolute time, use the dispatch.time_format to format the value.
+* `dispatch_index_earliest` - (Optional) A time string that specifies the earliest index time for this search. Can be a relative or absolute time. If this value is an absolute time, use the dispatch.time_format to format the value.
+* `dispatch_index_latest` - (Optional) A time string that specifies the latest index time for this search. Can be a relative or absolute time. If this value is an absolute time, use the dispatch.time_format to format the value.
+* `dispatch_indexed_realtime` - (Optional) A time string that specifies the earliest time for this search. Can be a relative or absolute time. If this value is an absolute time, use the dispatch.time_format to format the value.
 * `dispatch_indexed_realtime_minspan` - (Optional) Allows for a per-job override of the [search] indexed_realtime_disk_sync_delay setting in limits.conf.
 * `dispatch_indexed_realtime_offset` - (Optional) Allows for a per-job override of the [search] indexed_realtime_disk_sync_delay setting in limits.conf.
 * `dispatch_latest_time` - (Optional) A time string that specifies the latest time for this saved search. Can be a relative or absolute time.If this value is an absolute time, use the dispatch.time_format to format the value.

--- a/splunk/resource_splunk_saved_searches.go
+++ b/splunk/resource_splunk_saved_searches.go
@@ -647,6 +647,20 @@ func savedSearches() *schema.Resource {
 				Description: "A time string that specifies the earliest time for this search. Can be a relative or absolute time." +
 					"If this value is an absolute time, use the dispatch.time_format to format the value.",
 			},
+			"dispatch_index_earliest": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				Description: "A time string that specifies the latest time for this search. Can be a relative or absolute time." +
+					"If this value is an absolute time, use the dispatch.time_format to format the value.",
+			},
+			"dispatch_index_latest": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				Description: "A time string that specifies the earliest time for this search. Can be a relative or absolute time." +
+					"If this value is an absolute time, use the dispatch.time_format to format the value.",
+			},
 			"dispatch_indexed_realtime": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -1189,6 +1203,12 @@ func savedSearchesRead(d *schema.ResourceData, meta interface{}) error {
 	if err = d.Set("dispatch_earliest_time", entry.Content.DispatchEarliestTime); err != nil {
 		return err
 	}
+	if err = d.Set("dispatch_index_earliest", entry.Content.DispatchIndexEarliest); err != nil {
+		return err
+	}
+	if err = d.Set("dispatch_index_latest", entry.Content.DispatchIndexLatest); err != nil {
+		return err
+	}
 	if err = d.Set("dispatch_indexed_realtime", entry.Content.DispatchIndexedRealtime); err != nil {
 		return err
 	}
@@ -1417,6 +1437,8 @@ func getSavedSearchesConfig(d *schema.ResourceData) (savedSearchesObj *models.Sa
 		Disabled:                           d.Get("disabled").(bool),
 		DispatchBuckets:                    d.Get("dispatch_buckets").(int),
 		DispatchEarliestTime:               d.Get("dispatch_earliest_time").(string),
+		DispatchIndexEarliest:              d.Get("dispatch_index_earliest").(string),
+		DispatchIndexLatest:                d.Get("dispatch_index_latest").(string),
 		DispatchIndexedRealtime:            d.Get("dispatch_indexed_realtime").(bool),
 		DispatchIndexedRealtimeOffset:      d.Get("dispatch_indexed_realtime_offset").(int),
 		DispatchIndexedRealtimeMinspan:     d.Get("dispatch_indexed_realtime_minspan").(int),

--- a/splunk/resource_splunk_saved_searches_test.go
+++ b/splunk/resource_splunk_saved_searches_test.go
@@ -16,12 +16,14 @@ resource "splunk_saved_searches" "test" {
     action_email_format = "table"
     action_email_max_time = "5m"
     action_email_max_results = 10
-	action_email_send_results = false
-	action_email_subject = "Splunk Alert: $name$"
-	action_email_to = "splunk@splunk.com"
-	action_email_track_alert = true
+    action_email_send_results = false
+    action_email_subject = "Splunk Alert: $name$"
+    action_email_to = "splunk@splunk.com"
+    action_email_track_alert = true
     dispatch_earliest_time = "rt-15m"
     dispatch_latest_time = "rt-0m"
+    dispatch_index_earliest = "-10m"
+    dispatch_index_latest = "-5m"
     cron_schedule = "*/5 * * * *"
     acl {
       owner = "admin"
@@ -39,12 +41,14 @@ resource "splunk_saved_searches" "test" {
     action_email_format = "table"
     action_email_max_time = "5m"
     action_email_max_results = 100
-	action_email_send_results = false
-	action_email_subject = "Splunk Alert: $name$"
-	action_email_to = "splunk@splunk.com"
-	action_email_track_alert = true
+    action_email_send_results = false
+    action_email_subject = "Splunk Alert: $name$"
+    action_email_to = "splunk@splunk.com"
+    action_email_track_alert = true
     dispatch_earliest_time = "rt-15m"
     dispatch_latest_time = "rt-0m"
+    dispatch_index_earliest = "-20m"
+    dispatch_index_latest = "-5m"
     cron_schedule = "*/15 * * * *"
     acl {
       owner = "admin"
@@ -79,6 +83,8 @@ func TestAccSplunkSavedSearches(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "action_email_track_alert", "true"),
 					resource.TestCheckResourceAttr(resourceName, "dispatch_earliest_time", "rt-15m"),
 					resource.TestCheckResourceAttr(resourceName, "dispatch_latest_time", "rt-0m"),
+					resource.TestCheckResourceAttr(resourceName, "dispatch_index_earliest", "-10m"),
+					resource.TestCheckResourceAttr(resourceName, "dispatch_index_latest", "-5m"),
 					resource.TestCheckResourceAttr(resourceName, "cron_schedule", "*/5 * * * *"),
 				),
 			},
@@ -98,6 +104,8 @@ func TestAccSplunkSavedSearches(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "action_email_track_alert", "true"),
 					resource.TestCheckResourceAttr(resourceName, "dispatch_earliest_time", "rt-15m"),
 					resource.TestCheckResourceAttr(resourceName, "dispatch_latest_time", "rt-0m"),
+					resource.TestCheckResourceAttr(resourceName, "dispatch_index_earliest", "-20m"),
+					resource.TestCheckResourceAttr(resourceName, "dispatch_index_latest", "-5m"),
 					resource.TestCheckResourceAttr(resourceName, "cron_schedule", "*/15 * * * *"),
 				),
 			},


### PR DESCRIPTION
Resolves #15

As documented in https://docs.splunk.com/Documentation/Splunk/8.0.6/Admin/Savedsearchesconf#dispatch_search_options