### PR TITLE
Fix url encoding for searchers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ terraform.tfstate
 terraform.tfstate.backup
 *.log
 .DS_Store
+.vscode

--- a/client/client.go
+++ b/client/client.go
@@ -75,13 +75,7 @@ func (c *Client) BuildSplunkURL(queryValues url.Values, urlPathParts ...string) 
 	buildPath := ""
 	for _, pathPart := range urlPathParts {
 		pathPart = strings.ReplaceAll(pathPart, " ", "+") // url parameters cannot have spaces
-		if len(urlPathParts) > 5 && urlPathParts[4] == "searches" {
-			// URL encoding a search name will cause the special characters to be double encoded.
-			// for this reason we skip encoding this part of the URL when we are looking for a specific search
-			buildPath = path.Join(buildPath, pathPart)
-			continue
-		}
-		buildPath = path.Join(buildPath, url.PathEscape(pathPart))
+		buildPath = path.Join(buildPath, pathPart)
 	}
 	if queryValues == nil {
 		queryValues = url.Values{}

--- a/client/client.go
+++ b/client/client.go
@@ -75,6 +75,12 @@ func (c *Client) BuildSplunkURL(queryValues url.Values, urlPathParts ...string) 
 	buildPath := ""
 	for _, pathPart := range urlPathParts {
 		pathPart = strings.ReplaceAll(pathPart, " ", "+") // url parameters cannot have spaces
+		if len(urlPathParts) > 5 && urlPathParts[4] == "searches" {
+			// URL encoding a search name will cause the special characters to be double encoded.
+			// for this reason we skip encoding this part of the URL when we are looking for a specific search
+			buildPath = path.Join(buildPath, pathPart)
+			continue
+		}
 		buildPath = path.Join(buildPath, url.PathEscape(pathPart))
 	}
 	if queryValues == nil {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -41,6 +41,30 @@ func TestBuildSplunkURLNoURLPath(t *testing.T) {
 	}
 }
 
+func TestBuildSplunkURLSpecialCharactersInSearch(t *testing.T) {
+	client := NewDefaultSplunkdClient()
+	url := client.BuildSplunkURL(nil, "servicesNS", "admin", "search", "saved", "searches", "[some search]")
+
+	if got, want := url.Hostname(), "localhost"; got != want {
+		t.Errorf("hostname invalid, got %s, want %s", got, want)
+	}
+	if got, want := url.Scheme, defaultScheme; got != want {
+		t.Errorf("scheme invalid, got %s, want %s", got, want)
+	}
+	if got, want := url.Port(), "8089"; got != want {
+		t.Errorf("port invalid, got %s, want %s", got, want)
+	}
+	if got, want := url.Path, "servicesNS/admin/search/saved/searches/[some+search]"; got != want {
+		t.Errorf("path invalid, got %s, want %s", got, want)
+	}
+	if got, want := url.Fragment, ""; got != want {
+		t.Errorf("fragment invalid, got %s, want %s", got, want)
+	}
+	if url.User != nil {
+		t.Errorf("user invalid, got %s, want %v", url.User, nil)
+	}
+}
+
 func TestBuildSplunkURLNoHost(t *testing.T) {
 	client := NewDefaultSplunkdClient()
 	url := client.BuildSplunkURL(nil, "services",

--- a/client/inputs_monitor.go
+++ b/client/inputs_monitor.go
@@ -1,9 +1,11 @@
 package client
 
 import (
-	"github.com/google/go-querystring/query"
 	"net/http"
+	"net/url"
 	"terraform-provider-splunk/client/models"
+
+	"github.com/google/go-querystring/query"
 )
 
 func (client *Client) CreateMonitorInput(name string, owner string, app string, inputsMonitorObject *models.InputsMonitorObject) error {
@@ -23,7 +25,7 @@ func (client *Client) CreateMonitorInput(name string, owner string, app string, 
 }
 
 func (client *Client) ReadMonitorInput(name, owner, app string) (*http.Response, error) {
-	endpoint := client.BuildSplunkURL(nil, "servicesNS", owner, app, "data", "inputs", "monitor", name)
+	endpoint := client.BuildSplunkURL(nil, "servicesNS", owner, app, "data", "inputs", "monitor", url.PathEscape(name))
 	resp, err := client.Get(endpoint)
 	if err != nil {
 		return nil, err
@@ -34,7 +36,7 @@ func (client *Client) ReadMonitorInput(name, owner, app string) (*http.Response,
 
 func (client *Client) UpdateMonitorInput(name string, owner string, app string, inputsMonitorObject *models.InputsMonitorObject) error {
 	values, err := query.Values(&inputsMonitorObject)
-	endpoint := client.BuildSplunkURL(nil, "servicesNS", owner, app, "data", "inputs", "monitor", name)
+	endpoint := client.BuildSplunkURL(nil, "servicesNS", owner, app, "data", "inputs", "monitor", url.PathEscape(name))
 	resp, err := client.Post(endpoint, values)
 	if err != nil {
 		return err
@@ -44,7 +46,7 @@ func (client *Client) UpdateMonitorInput(name string, owner string, app string, 
 }
 
 func (client *Client) DeleteMonitorInput(name, owner, app string) (*http.Response, error) {
-	endpoint := client.BuildSplunkURL(nil, "servicesNS", owner, app, "data", "inputs", "monitor", name)
+	endpoint := client.BuildSplunkURL(nil, "servicesNS", owner, app, "data", "inputs", "monitor", url.PathEscape(name))
 	resp, err := client.Delete(endpoint)
 	if err != nil {
 		return nil, err

--- a/client/inputs_script.go
+++ b/client/inputs_script.go
@@ -1,9 +1,11 @@
 package client
 
 import (
-	"github.com/google/go-querystring/query"
 	"net/http"
+	"net/url"
 	"terraform-provider-splunk/client/models"
+
+	"github.com/google/go-querystring/query"
 )
 
 func (client *Client) CreateScriptedInput(name string, owner string, app string, inputsScriptObject *models.InputsScriptObject) error {
@@ -23,7 +25,7 @@ func (client *Client) CreateScriptedInput(name string, owner string, app string,
 }
 
 func (client *Client) ReadScriptedInput(name, owner, app string) (*http.Response, error) {
-	endpoint := client.BuildSplunkURL(nil, "servicesNS", owner, app, "data", "inputs", "script", name)
+	endpoint := client.BuildSplunkURL(nil, "servicesNS", owner, app, "data", "inputs", "script", url.PathEscape(name))
 	resp, err := client.Get(endpoint)
 	if err != nil {
 		return nil, err
@@ -34,7 +36,7 @@ func (client *Client) ReadScriptedInput(name, owner, app string) (*http.Response
 
 func (client *Client) UpdateScriptedInput(name string, owner string, app string, inputsScriptObject *models.InputsScriptObject) error {
 	values, err := query.Values(&inputsScriptObject)
-	endpoint := client.BuildSplunkURL(nil, "servicesNS", owner, app, "data", "inputs", "script", name)
+	endpoint := client.BuildSplunkURL(nil, "servicesNS", owner, app, "data", "inputs", "script", url.PathEscape(name))
 	resp, err := client.Post(endpoint, values)
 	if err != nil {
 		return err
@@ -44,7 +46,7 @@ func (client *Client) UpdateScriptedInput(name string, owner string, app string,
 }
 
 func (client *Client) DeleteScriptedInput(name, owner, app string) (*http.Response, error) {
-	endpoint := client.BuildSplunkURL(nil, "servicesNS", owner, app, "data", "inputs", "script", name)
+	endpoint := client.BuildSplunkURL(nil, "servicesNS", owner, app, "data", "inputs", "script", url.PathEscape(name))
 	resp, err := client.Delete(endpoint)
 	if err != nil {
 		return nil, err

--- a/client/inputs_tcp_splunk_tcp_token.go
+++ b/client/inputs_tcp_splunk_tcp_token.go
@@ -1,9 +1,11 @@
 package client
 
 import (
-	"github.com/google/go-querystring/query"
 	"net/http"
+	"net/url"
 	"terraform-provider-splunk/client/models"
+
+	"github.com/google/go-querystring/query"
 )
 
 func (client *Client) CreateSplunkTCPTokenInput(owner string, app string, inputsSplunkTCPTokenObject *models.InputsSplunkTCPTokenObject) error {
@@ -23,7 +25,7 @@ func (client *Client) CreateSplunkTCPTokenInput(owner string, app string, inputs
 }
 
 func (client *Client) ReadSplunkTCPTokenInput(name, owner, app string) (*http.Response, error) {
-	endpoint := client.BuildSplunkURL(nil, "servicesNS", owner, app, "data", "inputs", "tcp", "splunktcptoken", name)
+	endpoint := client.BuildSplunkURL(nil, "servicesNS", owner, app, "data", "inputs", "tcp", "splunktcptoken", url.PathEscape(name))
 	resp, err := client.Get(endpoint)
 	if err != nil {
 		return nil, err
@@ -34,7 +36,7 @@ func (client *Client) ReadSplunkTCPTokenInput(name, owner, app string) (*http.Re
 
 func (client *Client) UpdateSplunkTCPTokenInput(name string, owner string, app string, inputsSplunkTCPTokenObject *models.InputsSplunkTCPTokenObject) error {
 	values, err := query.Values(&inputsSplunkTCPTokenObject)
-	endpoint := client.BuildSplunkURL(nil, "servicesNS", owner, app, "data", "inputs", "tcp", "splunktcptoken", name)
+	endpoint := client.BuildSplunkURL(nil, "servicesNS", owner, app, "data", "inputs", "tcp", "splunktcptoken", url.PathEscape(name))
 	resp, err := client.Post(endpoint, values)
 	if err != nil {
 		return err
@@ -44,7 +46,7 @@ func (client *Client) UpdateSplunkTCPTokenInput(name string, owner string, app s
 }
 
 func (client *Client) DeleteSplunkTCPTokenInput(name, owner, app string) (*http.Response, error) {
-	endpoint := client.BuildSplunkURL(nil, "servicesNS", owner, app, "data", "inputs", "tcp", "splunktcptoken", name)
+	endpoint := client.BuildSplunkURL(nil, "servicesNS", owner, app, "data", "inputs", "tcp", "splunktcptoken", url.PathEscape(name))
 	resp, err := client.Delete(endpoint)
 	if err != nil {
 		return nil, err

--- a/splunk/resource_splunk_inputs_monitor.go
+++ b/splunk/resource_splunk_inputs_monitor.go
@@ -4,10 +4,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"net/http"
+	"net/url"
 	"regexp"
 	"terraform-provider-splunk/client/models"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func inputsMonitor() *schema.Resource {
@@ -134,7 +136,7 @@ func inputsMonitorCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if _, ok := d.GetOk("acl"); ok {
-		err := (*provider.Client).UpdateAcl(aclObject.Owner, aclObject.App, name, aclObject, "data", "inputs", "monitor")
+		err := (*provider.Client).UpdateAcl(aclObject.Owner, aclObject.App, url.PathEscape(name), aclObject, "data", "inputs", "monitor")
 		if err != nil {
 			return err
 		}
@@ -253,7 +255,7 @@ func inputsMonitorUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	//ACL update
-	err = (*provider.Client).UpdateAcl(aclObject.Owner, aclObject.App, d.Id(), aclObject, "data", "inputs", "monitor")
+	err = (*provider.Client).UpdateAcl(aclObject.Owner, aclObject.App, url.PathEscape(d.Id()), aclObject, "data", "inputs", "monitor")
 	if err != nil {
 		return err
 	}

--- a/splunk/resource_splunk_inputs_script.go
+++ b/splunk/resource_splunk_inputs_script.go
@@ -4,11 +4,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"net/http"
+	"net/url"
 	"regexp"
 	"terraform-provider-splunk/client/models"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
 func inputsScript() *schema.Resource {
@@ -99,7 +101,7 @@ func inputsScriptCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if _, ok := d.GetOk("acl"); ok {
-		err := (*provider.Client).UpdateAcl(aclObject.Owner, aclObject.App, name, aclObject, "data", "inputs", "script")
+		err := (*provider.Client).UpdateAcl(aclObject.Owner, aclObject.App, url.PathEscape(name), aclObject, "data", "inputs", "script")
 		if err != nil {
 			return err
 		}
@@ -190,7 +192,7 @@ func inputsScriptUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	//ACL update
-	err = (*provider.Client).UpdateAcl(aclObject.Owner, aclObject.App, d.Id(), aclObject, "data", "inputs", "script")
+	err = (*provider.Client).UpdateAcl(aclObject.Owner, aclObject.App, url.PathEscape(d.Id()), aclObject, "data", "inputs", "script")
 	if err != nil {
 		return err
 	}

--- a/splunk/resource_splunk_inputs_tcp_splunktcptoken.go
+++ b/splunk/resource_splunk_inputs_tcp_splunktcptoken.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"regexp"
 	"terraform-provider-splunk/client/models"
 
@@ -56,7 +57,7 @@ func inputsSplunkTCPTokenCreate(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	if _, ok := d.GetOk("acl"); ok {
-		err = (*provider.Client).UpdateAcl(aclObject.Owner, aclObject.App, name, aclObject, "data", "inputs", "tcp", "splunktcptoken")
+		err = (*provider.Client).UpdateAcl(aclObject.Owner, aclObject.App, url.PathEscape(name), aclObject, "data", "inputs", "tcp", "splunktcptoken")
 		if err != nil {
 			return err
 		}
@@ -127,7 +128,7 @@ func inputsSplunkTCPTokenUpdate(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	//ACL update
-	err = (*provider.Client).UpdateAcl(aclObject.Owner, aclObject.App, d.Id(), aclObject, "data", "inputs", "tcp", "splunktcptoken")
+	err = (*provider.Client).UpdateAcl(aclObject.Owner, aclObject.App, url.PathEscape(d.Id()), aclObject, "data", "inputs", "tcp", "splunktcptoken")
 	if err != nil {
 		return err
 	}

--- a/splunk/resource_splunk_inputs_tcp_splunktcptoken.go
+++ b/splunk/resource_splunk_inputs_tcp_splunktcptoken.go
@@ -4,10 +4,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"net/http"
 	"regexp"
 	"terraform-provider-splunk/client/models"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func inputsTCPSplunkTCPToken() *schema.Resource {

--- a/splunk/resource_splunk_saved_searches_test.go
+++ b/splunk/resource_splunk_saved_searches_test.go
@@ -2,10 +2,11 @@ package splunk
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"net/http"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 const newSavedSearches = `
@@ -39,6 +40,62 @@ resource "splunk_saved_searches" "test" {
 const updatedSavedSearches = `
 resource "splunk_saved_searches" "test" {
     name = "Test New Alert"
+    search = "index=main"
+    actions = "email"
+    action_email_include_search = 1
+    action_email_include_trigger = 1
+    action_email_format = "table"
+    action_email_max_time = "5m"
+    action_email_max_results = 100
+    action_email_send_csv = 1
+    action_email_send_results = false
+    action_email_subject = "Splunk Alert: $name$"
+    action_email_to = "splunk@splunk.com"
+    action_email_track_alert = true
+    dispatch_earliest_time = "rt-15m"
+    dispatch_latest_time = "rt-0m"
+    dispatch_index_earliest = "-20m"
+    dispatch_index_latest = "-5m"
+    cron_schedule = "*/15 * * * *"
+    acl {
+      owner = "admin"
+      sharing = "app"
+      app = "launcher"
+    }
+}
+`
+
+const newSavedSearchesBracket = `
+resource "splunk_saved_searches" "test" {
+    name = "[Test New Alert]"
+    search = "index=main"
+    actions = "email"
+    action_email_include_search = 0
+    action_email_include_trigger = 1
+    action_email_format = "table"
+    action_email_max_time = "5m"
+    action_email_max_results = 10
+    action_email_send_csv = 1
+    action_email_send_results = false
+    action_email_subject = "Splunk Alert: $name$"
+    action_email_to = "splunk@splunk.com"
+    action_email_track_alert = true
+    dispatch_earliest_time = "rt-15m"
+    dispatch_latest_time = "rt-0m"
+    dispatch_index_earliest = "-10m"
+    dispatch_index_latest = "-5m"
+    cron_schedule = "*/5 * * * *"
+    acl {
+      owner = "admin"
+      sharing = "app"
+      app = "launcher"
+    }
+}
+`
+
+const updateSavedSearchesBracket = `
+resource "splunk_saved_searches" "test" {
+    name = "[Test New Alert]"
     search = "index=main"
     actions = "email"
     action_email_include_search = 1
@@ -102,6 +159,56 @@ func TestAccSplunkSavedSearches(t *testing.T) {
 				Config: updatedSavedSearches,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", "Test New Alert"),
+					resource.TestCheckResourceAttr(resourceName, "search", "index=main"),
+					resource.TestCheckResourceAttr(resourceName, "actions", "email"),
+					resource.TestCheckResourceAttr(resourceName, "action_email", "true"),
+					resource.TestCheckResourceAttr(resourceName, "action_email_include_search", "1"),
+					resource.TestCheckResourceAttr(resourceName, "action_email_include_trigger", "1"),
+					resource.TestCheckResourceAttr(resourceName, "action_email_format", "table"),
+					resource.TestCheckResourceAttr(resourceName, "action_email_max_time", "5m"),
+					resource.TestCheckResourceAttr(resourceName, "action_email_max_results", "100"),
+					resource.TestCheckResourceAttr(resourceName, "action_email_send_csv", "1"),
+					resource.TestCheckResourceAttr(resourceName, "action_email_send_results", "false"),
+					resource.TestCheckResourceAttr(resourceName, "action_email_subject", "Splunk Alert: $name$"),
+					resource.TestCheckResourceAttr(resourceName, "action_email_to", "splunk@splunk.com"),
+					resource.TestCheckResourceAttr(resourceName, "action_email_track_alert", "true"),
+					resource.TestCheckResourceAttr(resourceName, "dispatch_earliest_time", "rt-15m"),
+					resource.TestCheckResourceAttr(resourceName, "dispatch_latest_time", "rt-0m"),
+					resource.TestCheckResourceAttr(resourceName, "dispatch_index_earliest", "-20m"),
+					resource.TestCheckResourceAttr(resourceName, "dispatch_index_latest", "-5m"),
+					resource.TestCheckResourceAttr(resourceName, "cron_schedule", "*/15 * * * *"),
+					resource.TestCheckResourceAttr(resourceName, "is_visible", "true"),
+				),
+			},
+			{
+				Config: newSavedSearchesBracket,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "[Test New Alert]"),
+					resource.TestCheckResourceAttr(resourceName, "search", "index=main"),
+					resource.TestCheckResourceAttr(resourceName, "actions", "email"),
+					resource.TestCheckResourceAttr(resourceName, "action_email", "true"),
+					resource.TestCheckResourceAttr(resourceName, "action_email_include_search", "0"),
+					resource.TestCheckResourceAttr(resourceName, "action_email_include_trigger", "1"),
+					resource.TestCheckResourceAttr(resourceName, "action_email_format", "table"),
+					resource.TestCheckResourceAttr(resourceName, "action_email_max_time", "5m"),
+					resource.TestCheckResourceAttr(resourceName, "action_email_max_results", "10"),
+					resource.TestCheckResourceAttr(resourceName, "action_email_send_csv", "1"),
+					resource.TestCheckResourceAttr(resourceName, "action_email_send_results", "false"),
+					resource.TestCheckResourceAttr(resourceName, "action_email_subject", "Splunk Alert: $name$"),
+					resource.TestCheckResourceAttr(resourceName, "action_email_to", "splunk@splunk.com"),
+					resource.TestCheckResourceAttr(resourceName, "action_email_track_alert", "true"),
+					resource.TestCheckResourceAttr(resourceName, "dispatch_earliest_time", "rt-15m"),
+					resource.TestCheckResourceAttr(resourceName, "dispatch_latest_time", "rt-0m"),
+					resource.TestCheckResourceAttr(resourceName, "dispatch_index_earliest", "-10m"),
+					resource.TestCheckResourceAttr(resourceName, "dispatch_index_latest", "-5m"),
+					resource.TestCheckResourceAttr(resourceName, "cron_schedule", "*/5 * * * *"),
+					resource.TestCheckResourceAttr(resourceName, "is_visible", "true"),
+				),
+			},
+			{
+				Config: updateSavedSearchesBracket,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "[Test New Alert]"),
 					resource.TestCheckResourceAttr(resourceName, "search", "index=main"),
 					resource.TestCheckResourceAttr(resourceName, "actions", "email"),
 					resource.TestCheckResourceAttr(resourceName, "action_email", "true"),


### PR DESCRIPTION
Addresses issue #26 by skipping URL encoding for search titles when building the splunk URL.

What is happening when there are special characters in a search's name, like `[` or `]` is that `BuildSplunkUrl` calls `PathEscape` on the search title. This encodes any special characters, so `[` becomes `%5B`. The problem is that `Url.Path` gets encoded again before a final request is sent so the final URL requested becomes `%255B` which decodes to `%5B` instead of `[`.

Here is a great example: https://stackoverflow.com/a/63626359

I attempted to avoid this by skipping the `PathEscape`, but that caused errors in the tcpInputs/outputs tests. I also attempted to use the `RawPath` and `Path` pieces of `Url` to include the encoded and non-encoded parts, respectfully. This caused the same errors as skipping encoding.

I opted to fix this by specifically skipping the encoding when we build URLs for specific searches. This feels a bit hacky so I'm open to better suggestions, but it works.


I added some tests, both for the `BuildSplunkUrl` method and the acceptance tests.