### PR TITLE
Changed module path to point to Splunk github repository

### DIFF
--- a/client/acl.go
+++ b/client/acl.go
@@ -3,7 +3,7 @@ package client
 import (
 	"net/http"
 	"strings"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
+	"github.com/splunk/terraform-provider-splunk/client/models"
 
 	"github.com/google/go-querystring/query"
 )

--- a/client/admin_saml_groups.go
+++ b/client/admin_saml_groups.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	"net/http"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
+	"github.com/splunk/terraform-provider-splunk/client/models"
 
 	"github.com/google/go-querystring/query"
 )

--- a/client/apps_local.go
+++ b/client/apps_local.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	"net/http"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
+	"github.com/splunk/terraform-provider-splunk/client/models"
 
 	"github.com/google/go-querystring/query"
 )

--- a/client/authentication_user.go
+++ b/client/authentication_user.go
@@ -1,8 +1,8 @@
 package client
 
 import (
+	"github.com/splunk/terraform-provider-splunk/client/models"
 	"net/http"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
 
 	"github.com/google/go-querystring/query"
 )

--- a/client/authorization_roles.go
+++ b/client/authorization_roles.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	"net/http"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
+	"github.com/splunk/terraform-provider-splunk/client/models"
 
 	"github.com/google/go-querystring/query"
 )

--- a/client/client.go
+++ b/client/client.go
@@ -14,7 +14,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-	"github.com/terraform-providers/terraform-provider-splunk/client/utils"
+	"github.com/splunk/terraform-provider-splunk/client/utils"
 	"time"
 )
 

--- a/client/configs_conf.go
+++ b/client/configs_conf.go
@@ -3,7 +3,7 @@ package client
 import (
 	"net/http"
 	"strings"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
+	"github.com/splunk/terraform-provider-splunk/client/models"
 
 	"github.com/google/go-querystring/query"
 )

--- a/client/index.go
+++ b/client/index.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	"net/http"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
+	"github.com/splunk/terraform-provider-splunk/client/models"
 
 	"github.com/google/go-querystring/query"
 )

--- a/client/inputs_global_http_event_collector.go
+++ b/client/inputs_global_http_event_collector.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	"net/http"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
+	"github.com/splunk/terraform-provider-splunk/client/models"
 
 	"github.com/google/go-querystring/query"
 )

--- a/client/inputs_http_event_collector.go
+++ b/client/inputs_http_event_collector.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	"net/http"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
+	"github.com/splunk/terraform-provider-splunk/client/models"
 
 	"github.com/google/go-querystring/query"
 )

--- a/client/inputs_monitor.go
+++ b/client/inputs_monitor.go
@@ -3,7 +3,7 @@ package client
 import (
 	"net/http"
 	"net/url"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
+	"github.com/splunk/terraform-provider-splunk/client/models"
 
 	"github.com/google/go-querystring/query"
 )

--- a/client/inputs_script.go
+++ b/client/inputs_script.go
@@ -3,7 +3,7 @@ package client
 import (
 	"net/http"
 	"net/url"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
+	"github.com/splunk/terraform-provider-splunk/client/models"
 
 	"github.com/google/go-querystring/query"
 )

--- a/client/inputs_tcp_cooked.go
+++ b/client/inputs_tcp_cooked.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	"net/http"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
+	"github.com/splunk/terraform-provider-splunk/client/models"
 
 	"github.com/google/go-querystring/query"
 )

--- a/client/inputs_tcp_raw.go
+++ b/client/inputs_tcp_raw.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	"net/http"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
+	"github.com/splunk/terraform-provider-splunk/client/models"
 
 	"github.com/google/go-querystring/query"
 )

--- a/client/inputs_tcp_splunk_tcp_token.go
+++ b/client/inputs_tcp_splunk_tcp_token.go
@@ -3,7 +3,7 @@ package client
 import (
 	"net/http"
 	"net/url"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
+	"github.com/splunk/terraform-provider-splunk/client/models"
 
 	"github.com/google/go-querystring/query"
 )

--- a/client/inputs_tcp_ssl.go
+++ b/client/inputs_tcp_ssl.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	"net/http"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
+	"github.com/splunk/terraform-provider-splunk/client/models"
 
 	"github.com/google/go-querystring/query"
 )

--- a/client/inputs_udp.go
+++ b/client/inputs_udp.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	"net/http"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
+	"github.com/splunk/terraform-provider-splunk/client/models"
 
 	"github.com/google/go-querystring/query"
 )

--- a/client/outputs_tcp_default.go
+++ b/client/outputs_tcp_default.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	"net/http"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
+	"github.com/splunk/terraform-provider-splunk/client/models"
 
 	"github.com/google/go-querystring/query"
 )

--- a/client/outputs_tcp_group.go
+++ b/client/outputs_tcp_group.go
@@ -3,7 +3,7 @@ package client
 import (
 	"net/http"
 	"strings"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
+	"github.com/splunk/terraform-provider-splunk/client/models"
 
 	"github.com/google/go-querystring/query"
 )

--- a/client/outputs_tcp_server.go
+++ b/client/outputs_tcp_server.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	"net/http"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
+	"github.com/splunk/terraform-provider-splunk/client/models"
 
 	"github.com/google/go-querystring/query"
 )

--- a/client/outputs_tcp_syslog.go
+++ b/client/outputs_tcp_syslog.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	"net/http"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
+	"github.com/splunk/terraform-provider-splunk/client/models"
 
 	"github.com/google/go-querystring/query"
 )

--- a/client/saved_searches.go
+++ b/client/saved_searches.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	"net/http"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
+	"github.com/splunk/terraform-provider-splunk/client/models"
 
 	"github.com/google/go-querystring/query"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/terraform-providers/terraform-provider-splunk
+module github.com/splunk/terraform-provider-splunk
 
 go 1.14
 

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/plugin"
-	"github.com/terraform-providers/terraform-provider-splunk/splunk"
+	"github.com/splunk/terraform-provider-splunk/splunk"
 )
 
 func main() {

--- a/splunk/acl.go
+++ b/splunk/acl.go
@@ -2,7 +2,7 @@ package splunk
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
+	"github.com/splunk/terraform-provider-splunk/client/models"
 )
 
 func aclSchema() *schema.Schema {

--- a/splunk/provider.go
+++ b/splunk/provider.go
@@ -1,7 +1,7 @@
 package splunk
 
 import (
-	"github.com/terraform-providers/terraform-provider-splunk/client"
+	"github.com/splunk/terraform-provider-splunk/client"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/splunk/provider_test.go
+++ b/splunk/provider_test.go
@@ -3,8 +3,8 @@ package splunk
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/splunk/terraform-provider-splunk/client"
 	"os"
-	"github.com/terraform-providers/terraform-provider-splunk/client"
 	"testing"
 	"time"
 )

--- a/splunk/resource_splunk_admin_saml_groups.go
+++ b/splunk/resource_splunk_admin_saml_groups.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/splunk/terraform-provider-splunk/client/models"
 	"net/http"
 	"regexp"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )

--- a/splunk/resource_splunk_apps_local.go
+++ b/splunk/resource_splunk_apps_local.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/splunk/terraform-provider-splunk/client/models"
 	"net/http"
 	"regexp"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )

--- a/splunk/resource_splunk_authentication_users.go
+++ b/splunk/resource_splunk_authentication_users.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/splunk/terraform-provider-splunk/client/models"
 	"net/http"
 	"regexp"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )

--- a/splunk/resource_splunk_authorization_roles.go
+++ b/splunk/resource_splunk_authorization_roles.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/splunk/terraform-provider-splunk/client/models"
 	"net/http"
 	"regexp"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )

--- a/splunk/resource_splunk_configs_conf.go
+++ b/splunk/resource_splunk_configs_conf.go
@@ -4,11 +4,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/splunk/terraform-provider-splunk/client/models"
 	"io/ioutil"
 	"net/http"
 	"regexp"
 	"strconv"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"

--- a/splunk/resource_splunk_global_http_event_collector.go
+++ b/splunk/resource_splunk_global_http_event_collector.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/splunk/terraform-provider-splunk/client/models"
 	"net/http"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
 )
 
 func globalHttpEventCollector() *schema.Resource {

--- a/splunk/resource_splunk_indexes.go
+++ b/splunk/resource_splunk_indexes.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/splunk/terraform-provider-splunk/client/models"
 	"net/http"
 	"regexp"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"

--- a/splunk/resource_splunk_inputs_http_event_collector.go
+++ b/splunk/resource_splunk_inputs_http_event_collector.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/splunk/terraform-provider-splunk/client/models"
 	"net/http"
 	"regexp"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )

--- a/splunk/resource_splunk_inputs_monitor.go
+++ b/splunk/resource_splunk_inputs_monitor.go
@@ -4,10 +4,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/splunk/terraform-provider-splunk/client/models"
 	"net/http"
 	"net/url"
 	"regexp"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )

--- a/splunk/resource_splunk_inputs_script.go
+++ b/splunk/resource_splunk_inputs_script.go
@@ -4,10 +4,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/splunk/terraform-provider-splunk/client/models"
 	"net/http"
 	"net/url"
 	"regexp"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"

--- a/splunk/resource_splunk_inputs_tcp_cooked.go
+++ b/splunk/resource_splunk_inputs_tcp_cooked.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/splunk/terraform-provider-splunk/client/models"
 	"net/http"
 	"regexp"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"

--- a/splunk/resource_splunk_inputs_tcp_raw.go
+++ b/splunk/resource_splunk_inputs_tcp_raw.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/splunk/terraform-provider-splunk/client/models"
 	"net/http"
 	"regexp"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"

--- a/splunk/resource_splunk_inputs_tcp_splunktcptoken.go
+++ b/splunk/resource_splunk_inputs_tcp_splunktcptoken.go
@@ -4,10 +4,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/splunk/terraform-provider-splunk/client/models"
 	"net/http"
 	"net/url"
 	"regexp"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )

--- a/splunk/resource_splunk_inputs_tcp_ssl.go
+++ b/splunk/resource_splunk_inputs_tcp_ssl.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/splunk/terraform-provider-splunk/client/models"
 	"net/http"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )

--- a/splunk/resource_splunk_inputs_udp.go
+++ b/splunk/resource_splunk_inputs_udp.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/splunk/terraform-provider-splunk/client/models"
 	"net/http"
 	"regexp"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"

--- a/splunk/resource_splunk_outputs_tcp_default.go
+++ b/splunk/resource_splunk_outputs_tcp_default.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/splunk/terraform-provider-splunk/client/models"
 	"net/http"
 	"regexp"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"

--- a/splunk/resource_splunk_outputs_tcp_default_test.go
+++ b/splunk/resource_splunk_outputs_tcp_default_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/splunk/terraform-provider-splunk/client/models"
 	"net/http"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
 	"testing"
 )
 

--- a/splunk/resource_splunk_outputs_tcp_group.go
+++ b/splunk/resource_splunk_outputs_tcp_group.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/splunk/terraform-provider-splunk/client/models"
 	"net/http"
 	"regexp"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"

--- a/splunk/resource_splunk_outputs_tcp_server.go
+++ b/splunk/resource_splunk_outputs_tcp_server.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/splunk/terraform-provider-splunk/client/models"
 	"net/http"
 	"regexp"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"

--- a/splunk/resource_splunk_outputs_tcp_syslog.go
+++ b/splunk/resource_splunk_outputs_tcp_syslog.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/splunk/terraform-provider-splunk/client/models"
 	"net/http"
 	"regexp"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"

--- a/splunk/resource_splunk_saved_searches.go
+++ b/splunk/resource_splunk_saved_searches.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/splunk/terraform-provider-splunk/client/models"
 	"net/http"
 	"regexp"
-	"github.com/terraform-providers/terraform-provider-splunk/client/models"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )


### PR DESCRIPTION
## Description

Pull request to update all module paths to point to [Splunk's github organization ](https://github.com/splunk/terraform-provider-splunk) rather than the https://github.com/terraform-providers Github organization, since this repo does not exist there.

All imports updated and go.mod updated.

closes #36 