### PR TITLE
Add email message field for reports & alerts

### DIFF
--- a/client/models/saved_searches.go
+++ b/client/models/saved_searches.go
@@ -31,6 +31,7 @@ type SavedSearchObject struct {
 	ActionEmailMailserver              string  `json:"action.email.mailserver,omitempty" url:"action.email.mailserver,omitempty"`
 	ActionEmailMaxResults              int     `json:"action.email.maxresults,omitempty" url:"action.email.maxresults,omitempty"`
 	ActionEmailMaxTime                 string  `json:"action.email.maxtime,omitempty" url:"action.email.maxtime,omitempty"`
+	ActionEmailMessageAlert            string  `json:"action.email.message.alert,omitempty" url:"action.email.message.alert,omitempty"`
 	ActionEmailPDFView                 string  `json:"action.email.pdfview,omitempty" url:"action.email.pdfview,omitempty"`
 	ActionEmailPreprocessResults       string  `json:"action.email.preprocess_results,omitempty" url:"action.email.preprocess_results,omitempty"`
 	ActionEmailReportCIDFontList       string  `json:"action.email.reportCIDFontList,omitempty" url:"action.email.reportCIDFontList,omitempty"`

--- a/client/models/saved_searches.go
+++ b/client/models/saved_searches.go
@@ -32,6 +32,7 @@ type SavedSearchObject struct {
 	ActionEmailMaxResults              int     `json:"action.email.maxresults,omitempty" url:"action.email.maxresults,omitempty"`
 	ActionEmailMaxTime                 string  `json:"action.email.maxtime,omitempty" url:"action.email.maxtime,omitempty"`
 	ActionEmailMessageAlert            string  `json:"action.email.message.alert,omitempty" url:"action.email.message.alert,omitempty"`
+	ActionEmailMessageReport           string  `json:"action.email.message.report,omitempty" url:"action.email.message.report,omitempty"`
 	ActionEmailPDFView                 string  `json:"action.email.pdfview,omitempty" url:"action.email.pdfview,omitempty"`
 	ActionEmailPreprocessResults       string  `json:"action.email.preprocess_results,omitempty" url:"action.email.preprocess_results,omitempty"`
 	ActionEmailReportCIDFontList       string  `json:"action.email.reportCIDFontList,omitempty" url:"action.email.reportCIDFontList,omitempty"`

--- a/docs/resources/saved_searches.md
+++ b/docs/resources/saved_searches.md
@@ -49,6 +49,7 @@ This resource block supports the following arguments:
 * `action_email_mailserver` - (Optional) Set the address of the MTA server to be used to send the emails.Defaults to <LOCALHOST> or whatever is set in alert_actions.conf.
 * `action_email_max_results` - (Optional) Sets the global maximum number of search results to send when email.action is enabled. Defaults to 100.
 * `action_email_max_time` - (Optional) Valid values are Integer[m|s|h|d].Specifies the maximum amount of time the execution of an email action takes before the action is aborted. Defaults to 5m.
+* `action_email_message_alert` - (Optional) Customize the message sent in the emailed alert. Defaults to: The alert condition for '$name$' was triggered.
 * `action_email_pdfview` - (Optional) The name of the view to deliver if sendpdf is enabled
 * `action_email_preprocess_results` - (Optional) Search string to preprocess results before emailing them. Defaults to empty string (no preprocessing).Usually the preprocessing consists of filtering out unwanted internal fields.
 * `action_email_report_cid_font_list` - (Optional) Space-separated list. Specifies the set (and load order) of CID fonts for handling Simplified Chinese(gb), Traditional Chinese(cns), Japanese(jp), and Korean(kor) in Integrated PDF Rendering.If multiple fonts provide a glyph for a given character code, the glyph from the first font specified in the list is used.To skip loading any CID fonts, specify the empty string.Defaults to 'gb cns jp kor'

--- a/docs/resources/saved_searches.md
+++ b/docs/resources/saved_searches.md
@@ -50,6 +50,7 @@ This resource block supports the following arguments:
 * `action_email_max_results` - (Optional) Sets the global maximum number of search results to send when email.action is enabled. Defaults to 100.
 * `action_email_max_time` - (Optional) Valid values are Integer[m|s|h|d].Specifies the maximum amount of time the execution of an email action takes before the action is aborted. Defaults to 5m.
 * `action_email_message_alert` - (Optional) Customize the message sent in the emailed alert. Defaults to: The alert condition for '$name$' was triggered.
+* `action_email_message_report` - (Optional) Customize the message sent in the emailed report. Defaults to: The scheduled report '$name$' has run
 * `action_email_pdfview` - (Optional) The name of the view to deliver if sendpdf is enabled
 * `action_email_preprocess_results` - (Optional) Search string to preprocess results before emailing them. Defaults to empty string (no preprocessing).Usually the preprocessing consists of filtering out unwanted internal fields.
 * `action_email_report_cid_font_list` - (Optional) Space-separated list. Specifies the set (and load order) of CID fonts for handling Simplified Chinese(gb), Traditional Chinese(cns), Japanese(jp), and Korean(kor) in Integrated PDF Rendering.If multiple fonts provide a glyph for a given character code, the glyph from the first font specified in the list is used.To skip loading any CID fonts, specify the empty string.Defaults to 'gb cns jp kor'

--- a/splunk/provider_test.go
+++ b/splunk/provider_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/splunk/terraform-provider-splunk/client"
 )
 
-// add a comment
 var testAccProviders map[string]terraform.ResourceProvider
 var testAccProvider *schema.Provider
 

--- a/splunk/provider_test.go
+++ b/splunk/provider_test.go
@@ -1,14 +1,16 @@
 package splunk
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/splunk/terraform-provider-splunk/client"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/splunk/terraform-provider-splunk/client"
 )
 
+// add a comment
 var testAccProviders map[string]terraform.ResourceProvider
 var testAccProvider *schema.Provider
 

--- a/splunk/resource_splunk_saved_searches.go
+++ b/splunk/resource_splunk_saved_searches.go
@@ -141,6 +141,12 @@ func savedSearches() *schema.Resource {
 				Description: "Valid values are Integer[m|s|h|d]." +
 					"Specifies the maximum amount of time the execution of an email action takes before the action is aborted. Defaults to 5m.",
 			},
+			"action_email_message_alert": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "Message sent in the emailed alert. Defaults to: The alert condition for '$name$' was triggered.",
+			},
 			"action_email_pdfview": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -1044,6 +1050,9 @@ func savedSearchesRead(d *schema.ResourceData, meta interface{}) error {
 	if err = d.Set("action_email_max_time", entry.Content.ActionEmailMaxTime); err != nil {
 		return err
 	}
+	if err = d.Set("action_email_message_alert", entry.Content.ActionEmailMessageAlert); err != nil {
+		return err
+	}
 	if err = d.Set("action_email_pdfview", entry.Content.ActionEmailPDFView); err != nil {
 		return err
 	}
@@ -1464,6 +1473,7 @@ func getSavedSearchesConfig(d *schema.ResourceData) (savedSearchesObj *models.Sa
 		ActionEmailMailserver:              d.Get("action_email_mailserver").(string),
 		ActionEmailMaxResults:              d.Get("action_email_max_results").(int),
 		ActionEmailMaxTime:                 d.Get("action_email_max_time").(string),
+		ActionEmailMessageAlert:            d.Get("action_email_message_alert").(string),
 		ActionEmailPDFView:                 d.Get("action_email_pdfview").(string),
 		ActionEmailPreprocessResults:       d.Get("action_email_preprocess_results").(string),
 		ActionEmailReportCIDFontList:       d.Get("action_email_report_cid_font_list").(string),

--- a/splunk/resource_splunk_saved_searches.go
+++ b/splunk/resource_splunk_saved_searches.go
@@ -147,6 +147,12 @@ func savedSearches() *schema.Resource {
 				Computed:    true,
 				Description: "Message sent in the emailed alert. Defaults to: The alert condition for '$name$' was triggered.",
 			},
+			"action_email_message_report": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "Message sent in the emailed report. Defaults to: The scheduled report '$name$' has run.",
+			},
 			"action_email_pdfview": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -1053,6 +1059,9 @@ func savedSearchesRead(d *schema.ResourceData, meta interface{}) error {
 	if err = d.Set("action_email_message_alert", entry.Content.ActionEmailMessageAlert); err != nil {
 		return err
 	}
+	if err = d.Set("action_email_message_report", entry.Content.ActionEmailMessageReport); err != nil {
+		return err
+	}
 	if err = d.Set("action_email_pdfview", entry.Content.ActionEmailPDFView); err != nil {
 		return err
 	}
@@ -1474,6 +1483,7 @@ func getSavedSearchesConfig(d *schema.ResourceData) (savedSearchesObj *models.Sa
 		ActionEmailMaxResults:              d.Get("action_email_max_results").(int),
 		ActionEmailMaxTime:                 d.Get("action_email_max_time").(string),
 		ActionEmailMessageAlert:            d.Get("action_email_message_alert").(string),
+		ActionEmailMessageReport:           d.Get("action_email_message_report").(string),
 		ActionEmailPDFView:                 d.Get("action_email_pdfview").(string),
 		ActionEmailPreprocessResults:       d.Get("action_email_preprocess_results").(string),
 		ActionEmailReportCIDFontList:       d.Get("action_email_report_cid_font_list").(string),

--- a/splunk/resource_splunk_saved_searches_test.go
+++ b/splunk/resource_splunk_saved_searches_test.go
@@ -143,6 +143,21 @@ resource "splunk_saved_searches" "test" {
 }
 `
 
+const newSavedSearchesReport = `
+resource "splunk_saved_searches" "test" {
+	name = "Test Report"
+    search = "index=main"
+    actions = "email"
+    action_email_include_search = 0
+    action_email_include_trigger = 1
+	action_email_format = "table"
+	action_email_to = "splunk@splunk.com"
+	is_scheduled = true
+	action_email_message_report = "a non-default message"
+	cron_schedule = "*/5 * * * *"
+}
+`
+
 func TestAccSplunkSavedSearches(t *testing.T) {
 	resourceName := "splunk_saved_searches.test"
 	resource.Test(t, resource.TestCase{
@@ -272,6 +287,21 @@ func TestAccSplunkSavedSearches(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "is_visible", "true"),
 					resource.TestCheckResourceAttr(resourceName, "realtime_schedule", "true"),
 					resource.TestCheckResourceAttr(resourceName, "search", "index=main level=error"),
+				),
+			},
+			{
+				Config: newSavedSearchesReport,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "Test Report"),
+					resource.TestCheckResourceAttr(resourceName, "search", "index=main"),
+					resource.TestCheckResourceAttr(resourceName, "actions", "email"),
+					resource.TestCheckResourceAttr(resourceName, "action_email", "true"),
+					resource.TestCheckResourceAttr(resourceName, "action_email_include_search", "0"),
+					resource.TestCheckResourceAttr(resourceName, "action_email_include_trigger", "1"),
+					resource.TestCheckResourceAttr(resourceName, "action_email_message_report", "a non-default message"),
+					resource.TestCheckResourceAttr(resourceName, "action_email_format", "table"),
+					resource.TestCheckResourceAttr(resourceName, "action_email_to", "splunk@splunk.com"),
+					resource.TestCheckResourceAttr(resourceName, "cron_schedule", "*/5 * * * *"),
 				),
 			},
 			{

--- a/splunk/resource_splunk_saved_searches_test.go
+++ b/splunk/resource_splunk_saved_searches_test.go
@@ -72,7 +72,8 @@ resource "splunk_saved_searches" "test" {
     actions = "email"
     action_email_include_search = 0
     action_email_include_trigger = 1
-    action_email_format = "table"
+	action_email_format = "table"
+	action_email_message_alert = "a non-default message"
     action_email_max_time = "5m"
     action_email_max_results = 10
     action_email_send_csv = 1
@@ -210,6 +211,7 @@ func TestAccSplunkSavedSearches(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "action_email", "true"),
 					resource.TestCheckResourceAttr(resourceName, "action_email_include_search", "0"),
 					resource.TestCheckResourceAttr(resourceName, "action_email_include_trigger", "1"),
+					resource.TestCheckResourceAttr(resourceName, "action_email_message_alert", "a non-default message"),
 					resource.TestCheckResourceAttr(resourceName, "action_email_format", "table"),
 					resource.TestCheckResourceAttr(resourceName, "action_email_max_time", "5m"),
 					resource.TestCheckResourceAttr(resourceName, "action_email_max_results", "10"),

--- a/splunk/resource_splunk_saved_searches_test.go
+++ b/splunk/resource_splunk_saved_searches_test.go
@@ -72,8 +72,8 @@ resource "splunk_saved_searches" "test" {
     actions = "email"
     action_email_include_search = 0
     action_email_include_trigger = 1
-	action_email_format = "table"
-	action_email_message_alert = "a non-default message"
+    action_email_format = "table"
+    action_email_message_alert = "a non-default message"
     action_email_max_time = "5m"
     action_email_max_results = 10
     action_email_send_csv = 1
@@ -145,16 +145,16 @@ resource "splunk_saved_searches" "test" {
 
 const newSavedSearchesReport = `
 resource "splunk_saved_searches" "test" {
-	name = "Test Report"
+    name = "Test Report"
     search = "index=main"
     actions = "email"
     action_email_include_search = 0
     action_email_include_trigger = 1
-	action_email_format = "table"
-	action_email_to = "splunk@splunk.com"
-	is_scheduled = true
-	action_email_message_report = "a non-default message"
-	cron_schedule = "*/5 * * * *"
+    action_email_format = "table"
+    action_email_to = "splunk@splunk.com"
+    is_scheduled = true
+    action_email_message_report = "a non-default message"
+    cron_schedule = "*/5 * * * *"
 }
 `
 


### PR DESCRIPTION
This adds a field to customize the alert message sent in an emailed alert.

Here's a snippet of the json response when you customize the alert message:

<img width="652" alt="Screen Shot 2020-11-18 at 8 13 39 PM" src="https://user-images.githubusercontent.com/8786230/99612094-8d969f00-29da-11eb-9598-ecb5c172ecf5.png">
