### PR TITLE
bugfix: http client overrides default transport and no longer support…

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -292,6 +292,7 @@ func NewSplunkdHTTPClient(timeout time.Duration, skipValidateTLS bool) *http.Cli
 	return &http.Client{
 		Timeout: timeout,
 		Transport: &http.Transport{
+			Proxy: http.DefaultTransport.(*http.Transport).Proxy,
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: skipValidateTLS},
 		},
 	}


### PR DESCRIPTION
…s environment proxy settings.

Golang default http client supports proxy settings from environment variables. This restores support for environment proxy variables where default client transport has been overridden. See the following link for the default behaviour: https://golang.org/src/net/http/transport.go

cc/ pls merge @ani0989 @anushjay 💖 