### PR TITLE
Metrics index param fix + metrics index test

### DIFF
--- a/client/index.go
+++ b/client/index.go
@@ -3,6 +3,7 @@ package client
 import (
 	"github.com/splunk/terraform-provider-splunk/client/models"
 	"net/http"
+	"net/url"
 
 	"github.com/google/go-querystring/query"
 )
@@ -24,7 +25,10 @@ func (client *Client) CreateIndexObject(name string, owner string, app string, i
 }
 
 func (client *Client) ReadIndexObject(name, owner, app string) (*http.Response, error) {
-	endpoint := client.BuildSplunkURL(nil, "servicesNS", owner, app, "data", "indexes", name)
+	queryValues := url.Values{}
+	queryValues.Add("datatype", "all")
+
+	endpoint := client.BuildSplunkURL(queryValues, "servicesNS", owner, app, "data", "indexes", name)
 	resp, err := client.Get(endpoint)
 	if err != nil {
 		return nil, err
@@ -38,11 +42,13 @@ func (client *Client) UpdateIndexObject(name string, owner string, app string, i
 	if err != nil {
 		return err
 	}
+	// Below values cannot be updated
 	values.Del("coldPath")
 	values.Del("datatype")
 	values.Del("homePath")
 	values.Del("thawedPath")
 	values.Del("tstatsHomePath")
+
 	endpoint := client.BuildSplunkURL(nil, "servicesNS", owner, app, "data", "indexes", name)
 	resp, err := client.Post(endpoint, values)
 	if err != nil {
@@ -64,7 +70,10 @@ func (client *Client) DeleteIndexObject(name, owner, app string) (*http.Response
 }
 
 func (client *Client) ReadAllIndexObject() (*http.Response, error) {
-	endpoint := client.BuildSplunkURL(nil, "servicesNS", "-", "-", "data", "indexes")
+	queryValues := url.Values{}
+	queryValues.Add("datatype", "all")
+
+	endpoint := client.BuildSplunkURL(queryValues, "servicesNS", "-", "-", "data", "indexes")
 	resp, err := client.Get(endpoint)
 	if err != nil {
 		return nil, err

--- a/splunk/resource_splunk_metrics_index_test.go
+++ b/splunk/resource_splunk_metrics_index_test.go
@@ -5,46 +5,48 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"net/http"
+	"net/url"
 	"testing"
 	"time"
 )
 
-const newIndex = `
-resource "splunk_indexes" "new-index" {
-    name = "new-index"
+const newMetricsIndex = `
+resource "splunk_indexes" "new-metrics-index" {
+    name = "new-metrics-index"
+	datatype = "metric"
 }
 `
 
-const updateIndex = `
-resource "splunk_indexes" "new-index" {
-	name = "new-index"
+const updateMetricsIndex = `
+resource "splunk_indexes" "new-metrics-index" {
+	name = "new-metrics-index"
     max_time_unreplicated_no_acks = 301
 }
 `
 
-func TestAccCreateSplunkIndex(t *testing.T) {
-	resourceName := "splunk_indexes.new-index"
+func TestAccCreateSplunkMetricsIndex(t *testing.T) {
+	resourceName := "splunk_indexes.new-metrics-index"
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
 		Providers:    testAccProviders,
-		CheckDestroy: testAccSplunkIndexDestroyResources,
+		CheckDestroy: testAccSplunkMetricsIndexDestroyResources,
 		Steps: []resource.TestStep{
 			{
-				Config: newIndex,
+				Config: newMetricsIndex,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "max_time_unreplicated_no_acks", "300"),
 				),
 			},
 			{
-				Config: updateIndex,
+				Config: updateMetricsIndex,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "max_time_unreplicated_no_acks", "301"),
 				),
 			},
 			{
-				ResourceName:      "splunk_indexes.new-index",
+				ResourceName:      "splunk_indexes.new-metrics-index",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -52,12 +54,15 @@ func TestAccCreateSplunkIndex(t *testing.T) {
 	})
 }
 
-func testAccSplunkIndexDestroyResources(s *terraform.State) error {
+func testAccSplunkMetricsIndexDestroyResources(s *terraform.State) error {
 	client := newTestClient()
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "splunk_indexes":
-			endpoint := client.BuildSplunkURL(nil, "services", "data", "indexes", rs.Primary.ID)
+			queryValues := url.Values{}
+			queryValues.Add("datatype", "all")
+
+			endpoint := client.BuildSplunkURL(queryValues, "services", "data", "indexes", rs.Primary.ID)
 			// Index delete is asynchronous - brief wait to ensure deletion has completed
 			time.Sleep(2 * time.Second)
 			resp, err := client.Get(endpoint)


### PR DESCRIPTION
Adds a query param to get/list requests for indexes. By default only indexes with the datatype 'event' are returned. 

Also adds a new test for metrics indexes.