### PR TITLE
Update Documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,17 @@ provider "splunk" {
 }
 ```
 
+Terraform 0.13 and later must add:
+```
+terraform {
+   required_providers {
+    splunk = {
+      source  = "splunk/splunk"
+    }
+  }
+}
+```
+
 ## Argument Reference
 
 Below arguments for the provider can also be set as environment variables.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# <provider> Provider
+# Splunk Provider
 
 The Splunk provider can interact with the resources supported by Splunk. The provider needs to be configured with the proper credentials before it can be used.
 


### PR DESCRIPTION
Upon loading the docs for the first time, I noticed the page said "`<provider> Provider`. Replaced the template `<provider>` with Splunk.

Link: https://registry.terraform.io/providers/splunk/splunk/latest/docs

![Screen Shot 2021-02-15 at 3 43 46 PM](https://user-images.githubusercontent.com/361546/107991456-9fb9b680-6fa4-11eb-9709-4f3226585290.png)
