### PR TITLE
Correct title on documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# <provider> Provider
+# Splunk Provider
 
 The Splunk provider can interact with the resources supported by Splunk. The provider needs to be configured with the proper credentials before it can be used.
 


### PR DESCRIPTION
The title of the Splunk Terraform provider's page currently says `<provider> Provider` - this PR and change corrects that.