### PR TITLE
Adds Cookie handling (fixes #49)

### DIFF
--- a/splunk/provider_test.go
+++ b/splunk/provider_test.go
@@ -26,14 +26,18 @@ func init() {
 	}
 }
 
-func newTestClient() *client.Client {
-	client := client.NewSplunkdClient(
+func newTestClient() (*client.Client, error) {
+	http, err := client.NewSplunkdHTTPClient(30*time.Second, true)
+	if err != nil {
+		return nil, err
+	}
+	return client.NewSplunkdClient(
 		"",
 		[2]string{os.Getenv("SPLUNK_USERNAME"),
 			os.Getenv("SPLUNK_PASSWORD")},
 		os.Getenv("SPLUNK_URL"),
-		client.NewSplunkdHTTPClient(30*time.Second, true))
-	return client
+
+		http)
 }
 
 func testAccPreCheck(t *testing.T) {

--- a/splunk/resource_splunk_admin_saml_groups_test.go
+++ b/splunk/resource_splunk_admin_saml_groups_test.go
@@ -60,7 +60,10 @@ func TestAccSplunkAdminSAMLGroups(t *testing.T) {
 }
 
 func testAccSplunkAdminSAMLGroupsInputDestroyResources(s *terraform.State) error {
-	client := newTestClient()
+	client, err := newTestClient()
+	if err != nil {
+		return err
+	}
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "splunk_authorization_roles":

--- a/splunk/resource_splunk_apps_local_test.go
+++ b/splunk/resource_splunk_apps_local_test.go
@@ -71,7 +71,10 @@ func TestAccSplunkAppsLocal(t *testing.T) {
 }
 
 func testAccSplunkAppsLocalDestroyResources(s *terraform.State) error {
-	client := newTestClient()
+	client, err := newTestClient()
+	if err != nil {
+		return err
+	}
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "splunk_apps_local":

--- a/splunk/resource_splunk_authentication_users_test.go
+++ b/splunk/resource_splunk_authentication_users_test.go
@@ -67,7 +67,10 @@ func TestAccSplunkAuthenticationUsers(t *testing.T) {
 }
 
 func testAccSplunkAuthenticationUsersInputDestroyResources(s *terraform.State) error {
-	client := newTestClient()
+	client, err := newTestClient()
+	if err != nil {
+		return err
+	}
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "splunk_authentication_users":

--- a/splunk/resource_splunk_authorization_roles_test.go
+++ b/splunk/resource_splunk_authorization_roles_test.go
@@ -89,7 +89,10 @@ func TestAccSplunkAuthorizationRoles(t *testing.T) {
 }
 
 func testAccSplunkAuthorizationRolesInputDestroyResources(s *terraform.State) error {
-	client := newTestClient()
+	client, err := newTestClient()
+	if err != nil {
+		return err
+	}
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "splunk_authorization_roles":

--- a/splunk/resource_splunk_configs_conf_test.go
+++ b/splunk/resource_splunk_configs_conf_test.go
@@ -61,7 +61,10 @@ func TestAccCreateSplunkConfigsConf(t *testing.T) {
 }
 
 func testAccSplunkConfigsConfDestroyResources(s *terraform.State) error {
-	client := newTestClient()
+	client, err := newTestClient()
+	if err != nil {
+		return err
+	}
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "splunk_configs_conf":

--- a/splunk/resource_splunk_data_ui_views_test.go
+++ b/splunk/resource_splunk_data_ui_views_test.go
@@ -127,7 +127,10 @@ func TestAccSplunkDashboardsWithAcl(t *testing.T) {
 }
 
 func testAccSplunkDashboardDestroyResources(s *terraform.State) error {
-	client := newTestClient()
+	client, err := newTestClient()
+	if err != nil {
+		return err
+	}
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "splunk_data_ui_views":

--- a/splunk/resource_splunk_global_http_event_collector_test.go
+++ b/splunk/resource_splunk_global_http_event_collector_test.go
@@ -67,7 +67,10 @@ func TestAccGlobalSplunkHttpEventCollectorInput(t *testing.T) {
 }
 
 func testAccSplunkGlobalHttpInputDestroyResources(s *terraform.State) error {
-	client := newTestClient()
+	client, err := newTestClient()
+	if err != nil {
+		return err
+	}
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		default:

--- a/splunk/resource_splunk_indexes_test.go
+++ b/splunk/resource_splunk_indexes_test.go
@@ -53,7 +53,10 @@ func TestAccCreateSplunkIndex(t *testing.T) {
 }
 
 func testAccSplunkIndexDestroyResources(s *terraform.State) error {
-	client := newTestClient()
+	client, err := newTestClient()
+	if err != nil {
+		return err
+	}
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "splunk_indexes":

--- a/splunk/resource_splunk_inputs_http_event_collector_test.go
+++ b/splunk/resource_splunk_inputs_http_event_collector_test.go
@@ -164,7 +164,10 @@ func TestAccSplunkHttpEventCollectorInputWithToken(t *testing.T) {
 }
 
 func testAccSplunkHttpEventCollectorInputDestroyResources(s *terraform.State) error {
-	client := newTestClient()
+	client, err := newTestClient()
+	if err != nil {
+		return err
+	}
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "splunk_inputs_http_event_collector":

--- a/splunk/resource_splunk_inputs_monitor_test.go
+++ b/splunk/resource_splunk_inputs_monitor_test.go
@@ -68,7 +68,10 @@ func TestAccSplunkInputsMonitor(t *testing.T) {
 }
 
 func testAccSplunkInputsMonitorDestroyResources(s *terraform.State) error {
-	client := newTestClient()
+	client, err := newTestClient()
+	if err != nil {
+		return err
+	}
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		default:

--- a/splunk/resource_splunk_inputs_script_test.go
+++ b/splunk/resource_splunk_inputs_script_test.go
@@ -63,7 +63,10 @@ func TestAccSplunkInputsScript(t *testing.T) {
 }
 
 func testAccSplunkInputsScriptDestroyResources(s *terraform.State) error {
-	client := newTestClient()
+	client, err := newTestClient()
+	if err != nil {
+		return err
+	}
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		default:

--- a/splunk/resource_splunk_inputs_tcp_cooked_test.go
+++ b/splunk/resource_splunk_inputs_tcp_cooked_test.go
@@ -60,7 +60,10 @@ func TestAccSplunkTCPCookedInput(t *testing.T) {
 }
 
 func testAccSplunkTCPCookedInputDestroyResources(s *terraform.State) error {
-	client := newTestClient()
+	client, err := newTestClient()
+	if err != nil {
+		return err
+	}
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "splunk_inputs_tcp_cooked":

--- a/splunk/resource_splunk_inputs_tcp_raw_test.go
+++ b/splunk/resource_splunk_inputs_tcp_raw_test.go
@@ -70,7 +70,10 @@ func TestAccSplunkTCPRawInput(t *testing.T) {
 }
 
 func testAccSplunkTCPRawInputDestroyResources(s *terraform.State) error {
-	client := newTestClient()
+	client, err := newTestClient()
+	if err != nil {
+		return err
+	}
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "splunk_inputs_tcp_raw":

--- a/splunk/resource_splunk_inputs_tcp_splunktcptoken_test.go
+++ b/splunk/resource_splunk_inputs_tcp_splunktcptoken_test.go
@@ -41,7 +41,10 @@ func TestAccSplunkTCPTokenInput(t *testing.T) {
 }
 
 func testAccSplunkTCPTokenInputDestroyResources(s *terraform.State) error {
-	client := newTestClient()
+	client, err := newTestClient()
+	if err != nil {
+		return err
+	}
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "splunk_inputs_tcp_splunk_tcp_token":

--- a/splunk/resource_splunk_inputs_tcp_ssl_test.go
+++ b/splunk/resource_splunk_inputs_tcp_ssl_test.go
@@ -56,7 +56,10 @@ func TestAccInputsTCPSSL(t *testing.T) {
 }
 
 func testAccTCPSSLInputDestroyResources(s *terraform.State) error {
-	client := newTestClient()
+	client, err := newTestClient()
+	if err != nil {
+		return err
+	}
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		default:

--- a/splunk/resource_splunk_inputs_udp_test.go
+++ b/splunk/resource_splunk_inputs_udp_test.go
@@ -72,7 +72,10 @@ func TestAccSplunkUDPInput(t *testing.T) {
 }
 
 func testAccSplunkUDPInputDestroyResources(s *terraform.State) error {
-	client := newTestClient()
+	client, err := newTestClient()
+	if err != nil {
+		return err
+	}
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "splunk_inputs_udp":

--- a/splunk/resource_splunk_metrics_index_test.go
+++ b/splunk/resource_splunk_metrics_index_test.go
@@ -55,7 +55,10 @@ func TestAccCreateSplunkMetricsIndex(t *testing.T) {
 }
 
 func testAccSplunkMetricsIndexDestroyResources(s *terraform.State) error {
-	client := newTestClient()
+	client, err := newTestClient()
+	if err != nil {
+		return err
+	}
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "splunk_indexes":

--- a/splunk/resource_splunk_outputs_tcp_default_test.go
+++ b/splunk/resource_splunk_outputs_tcp_default_test.go
@@ -77,7 +77,10 @@ func TestAccSplunkTCPDefaultOutput(t *testing.T) {
 }
 
 func testAccSplunkTCPDefaultOutputDestroyResources(s *terraform.State) error {
-	client := newTestClient()
+	client, err := newTestClient()
+	if err != nil {
+		return err
+	}
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "splunk_outputs_tcp_default":

--- a/splunk/resource_splunk_outputs_tcp_group_test.go
+++ b/splunk/resource_splunk_outputs_tcp_group_test.go
@@ -76,7 +76,10 @@ func TestAccSplunkTCPGroupOutput(t *testing.T) {
 }
 
 func testAccSplunkTCPGroupOutputDestroyResources(s *terraform.State) error {
-	client := newTestClient()
+	client, err := newTestClient()
+	if err != nil {
+		return err
+	}
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "splunk_outputs_tcp_group":

--- a/splunk/resource_splunk_outputs_tcp_server_test.go
+++ b/splunk/resource_splunk_outputs_tcp_server_test.go
@@ -57,7 +57,10 @@ func TestAccSplunkTCPServerOutput(t *testing.T) {
 }
 
 func testAccSplunkTCPServerOutputDestroyResources(s *terraform.State) error {
-	client := newTestClient()
+	client, err := newTestClient()
+	if err != nil {
+		return err
+	}
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "splunk_outputs_tcp_server":

--- a/splunk/resource_splunk_outputs_tcp_syslog_test.go
+++ b/splunk/resource_splunk_outputs_tcp_syslog_test.go
@@ -60,7 +60,10 @@ func TestAccSplunkTCPSyslogOutput(t *testing.T) {
 }
 
 func testAccSplunkTCPSyslogOutputDestroyResources(s *terraform.State) error {
-	client := newTestClient()
+	client, err := newTestClient()
+	if err != nil {
+		return err
+	}
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "splunk_outputs_tcp_syslog":

--- a/splunk/resource_splunk_saved_searches_test.go
+++ b/splunk/resource_splunk_saved_searches_test.go
@@ -320,7 +320,10 @@ func TestAccSplunkSavedSearches(t *testing.T) {
 }
 
 func testAccSplunkSavedSearchesDestroyResources(s *terraform.State) error {
-	client := newTestClient()
+	client, err := newTestClient()
+	if err != nil {
+		return err
+	}
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "splunk_saved_searches":


### PR DESCRIPTION
AWS LB expects cookies to be sent back - see https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-sticky-sessions.html

Didn't think this was worthy of a config option, but let me know.