### PR TITLE
#76 Use Defaults for authorization/roles that will have defaults applied by Splunk anyway.

### DIFF
--- a/client/models/authorization_roles.go
+++ b/client/models/authorization_roles.go
@@ -14,16 +14,16 @@ type AuthorizationRolesEntry struct {
 
 type AuthorizationRolesObject struct {
 	Capabilities              []string `json:"capabilities,omitempty" url:"capabilities,omitempty"`
-	CumulativeRTSrchJobsQuota int      `json:"cumulativeRTSrchJobsQuota,omitempty" url:"cumulativeRTSrchJobsQuota,omitempty"`
-	CumulativeSrchJobsQuota   int      `json:"cumulativeSrchJobsQuota,omitempty" url:"cumulativeSrchJobsQuota,omitempty"`
+	CumulativeRTSrchJobsQuota int      `json:"cumulativeRTSrchJobsQuota" url:"cumulativeRTSrchJobsQuota"`
+	CumulativeSrchJobsQuota   int      `json:"cumulativeSrchJobsQuota" url:"cumulativeSrchJobsQuota"`
 	DefaultApp                string   `json:"defaultApp,omitempty" url:"defaultApp,omitempty"`
 	ImportedRoles             []string `json:"imported_roles,omitempty" url:"imported_roles,omitempty"`
 	Name                      string   `json:"name,omitempty" url:"name,omitempty"`
-	RtSrchJobsQuota           int      `json:"rtSrchJobsQuota,omitempty" url:"rtSrchJobsQuota,omitempty"`
-	SrchDiskQuota             int      `json:"srchDiskQuota,omitempty" url:"srchDiskQuota,omitempty"`
+	RtSrchJobsQuota           int      `json:"rtSrchJobsQuota" url:"rtSrchJobsQuota"`
+	SrchDiskQuota             int      `json:"srchDiskQuota" url:"srchDiskQuota"`
 	SrchFilter                string   `json:"srchFilter,omitempty" url:"srchFilter,omitempty"`
 	SrchIndexesAllowed        []string `json:"srchIndexesAllowed,omitempty" url:"srchIndexesAllowed,omitempty"`
 	SrchIndexesDefault        []string `json:"srchIndexesDefault,omitempty" url:"srchIndexesDefault,omitempty"`
-	SrchJobsQuota             int      `json:"srchJobsQuota,omitempty" url:"srchJobsQuota,omitempty"`
-	SrchTimeWin               int      `json:"srchTimeWin,omitempty" url:"srchTimeWin,omitempty"`
+	SrchJobsQuota             int      `json:"srchJobsQuota" url:"srchJobsQuota"`
+	SrchTimeWin               int      `json:"srchTimeWin" url:"srchTimeWin"`
 }

--- a/splunk/resource_splunk_authorization_roles.go
+++ b/splunk/resource_splunk_authorization_roles.go
@@ -32,13 +32,13 @@ func authorizationRoles() *schema.Resource {
 			"cumulative_realtime_search_jobs_quota": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Computed:    true,
+				Default:     0,
 				Description: "Maximum number of concurrently running real-time searches that all members of this role can have.",
 			},
 			"cumulative_search_jobs_quota": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Computed:    true,
+				Default:     0,
 				Description: "Maximum number of concurrently running searches for all role members. Warning message logged when limit is reached.",
 			},
 			"default_app": {
@@ -62,13 +62,13 @@ func authorizationRoles() *schema.Resource {
 			"realtime_search_jobs_quota": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Computed:    true,
+				Default:     6,
 				Description: "Specify the maximum number of concurrent real-time search jobs for this role. This count is independent from the normal search jobs limit.",
 			},
 			"search_disk_quota": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Computed:    true,
+				Default:     100,
 				Description: "Specifies the maximum disk space in MB that can be used by a user's search jobs. For example, a value of 100 limits this role to 100 MB total.",
 			},
 			"search_filter": {
@@ -123,13 +123,13 @@ func authorizationRoles() *schema.Resource {
 			"search_jobs_quota": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Computed:    true,
+				Default:     3,
 				Description: "The maximum number of concurrent searches a user with this role is allowed to run. For users with multiple roles, the maximum quota value among all of the roles applies.",
 			},
 			"search_time_win": {
 				Type:     schema.TypeInt,
 				Optional: true,
-				Computed: true,
+				Default:  -1,
 				Description: "Maximum time span of a search, in seconds. By default, searches are not limited to any specific time window. " +
 					"To override any search time windows from imported roles, set srchTimeWin to '0', as the 'admin' role does.",
 			},


### PR DESCRIPTION
By setting these defaults we can remove "omitempty" for these values, enabling the setting of explicit zero values.