### PR TITLE
Add support for webhook alert action

### DIFF
--- a/client/models/saved_searches.go
+++ b/client/models/saved_searches.go
@@ -88,6 +88,7 @@ type SavedSearchObject struct {
 	ActionSlackParamFields             string  `json:"action.slack.param.fields,omitempty" url:"action.slack.param.fields"`
 	ActionSlackParamMessage            string  `json:"action.slack.param.message,omitempty" url:"action.slack.param.message"`
 	ActionSlackParamWebhookUrlOverride string  `json:"action.slack.param.webhook_url_override,omitempty" url:"action.slack.param.webhook_url_override"`
+	ActionWebhookParamUrl              string  `json:"action.webhook.param.url,omitempty" url:"action.webhook.param.url"`
 	AlertDigestMode                    bool    `json:"alert.digest_mode" url:"alert.digest_mode"`
 	AlertExpires                       string  `json:"alert.expires,omitempty" url:"alert.expires,omitempty"`
 	AlertSeverity                      int     `json:"alert.severity,omitempty" url:"alert.severity,omitempty"`

--- a/docs/resources/saved_searches.md
+++ b/docs/resources/saved_searches.md
@@ -106,6 +106,7 @@ This resource block supports the following arguments:
 * `action_slack_param_attachment` - (Optional) Include a message attachment. Valid values are message, none, or alert_link
 * `action_slack_param_message` - (Optional) Enter the chat message to send to the Slack channel. The message can include tokens that insert text based on the results of the search.
 * `action_slack_param_webhook_url_override` - (Optional) You can override the Slack webhook URL here if you need to send the alert message to a different Slack team
+* `action_webhook_param_url` - (Optional) URL to send the HTTP POST request to. Must be accessible from the Splunk server
 * `actions` - (Optional) A comma-separated list of actions to enable. For example: rss,email
 * `alert_comparator` - (Optional) One of the following strings: greater than, less than, equal to, rises by, drops by, rises by perc, drops by percUsed with alert_threshold to trigger alert actions.
 * `alert_condition` - (Optional) Contains a conditional search that is evaluated against the results of the saved search. Defaults to an empty string.

--- a/splunk/resource_splunk_saved_searches.go
+++ b/splunk/resource_splunk_saved_searches.go
@@ -513,6 +513,11 @@ func savedSearches() *schema.Resource {
 				Optional:    true,
 				Description: "You can override the Slack webhook URL here if you need to send the alert message to a different Slack team.",
 			},
+			"action_webhook_param_url": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "URL to send the HTTP POST request to. Must be accessible from the Splunk server.",
+			},
 			"alert_digest_mode": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -1256,6 +1261,9 @@ func savedSearchesRead(d *schema.ResourceData, meta interface{}) error {
 	if err = d.Set("action_slack_param_webhook_url_override", entry.Content.ActionSlackParamWebhookUrlOverride); err != nil {
 		return err
 	}
+	if err = d.Set("action_webhook_param_url", entry.Content.ActionWebhookParamUrl); err != nil {
+		return err
+	}
 	if err = d.Set("alert_digest_mode", entry.Content.AlertDigestMode); err != nil {
 		return err
 	}
@@ -1565,6 +1573,7 @@ func getSavedSearchesConfig(d *schema.ResourceData) (savedSearchesObj *models.Sa
 		ActionSlackParamFields:             d.Get("action_slack_param_fields").(string),
 		ActionSlackParamMessage:            d.Get("action_slack_param_message").(string),
 		ActionSlackParamWebhookUrlOverride: d.Get("action_slack_param_webhook_url_override").(string),
+		ActionWebhookParamUrl:              d.Get("action_webhook_param_url").(string),
 		AlertComparator:                    d.Get("alert_comparator").(string),
 		AlertCondition:                     d.Get("alert_condition").(string),
 		AlertDigestMode:                    d.Get("alert_digest_mode").(bool),

--- a/splunk/resource_splunk_saved_searches.go
+++ b/splunk/resource_splunk_saved_searches.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/splunk/terraform-provider-splunk/client/models"
 )
 
@@ -514,9 +515,10 @@ func savedSearches() *schema.Resource {
 				Description: "You can override the Slack webhook URL here if you need to send the alert message to a different Slack team.",
 			},
 			"action_webhook_param_url": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "URL to send the HTTP POST request to. Must be accessible from the Splunk server.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  "URL to send the HTTP POST request to. Must be accessible from the Splunk server.",
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^https?://[^\s]+$`), "Webhook URL is invalid"),
 			},
 			"alert_digest_mode": {
 				Type:     schema.TypeBool,

--- a/splunk/resource_splunk_saved_searches_test.go
+++ b/splunk/resource_splunk_saved_searches_test.go
@@ -151,7 +151,7 @@ const newSavedSearchesWebhook = `
 resource "splunk_saved_searches" "test" {
 	name = "Test Slack Alert"
 	actions = "webhook"
-	action_webhook_param_url = "localhost:1234"
+	action_webhook_param_url = "http://localhost:1234"
 	alert_comparator    = "greater than"
 	alert_digest_mode   = true
 	alert_expires       = "30d"
@@ -319,7 +319,7 @@ func TestAccSplunkSavedSearches(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", "Test Slack Alert"),
 					resource.TestCheckResourceAttr(resourceName, "actions", "webhook"),
-					resource.TestCheckResourceAttr(resourceName, "action_webhook_param_url", "localhost:1234"),
+					resource.TestCheckResourceAttr(resourceName, "action_webhook_param_url", "http://localhost:1234"),
 					resource.TestCheckResourceAttr(resourceName, "alert_comparator", "greater than"),
 					resource.TestCheckResourceAttr(resourceName, "alert_digest_mode", "true"),
 					resource.TestCheckResourceAttr(resourceName, "alert_expires", "30d"),

--- a/splunk/resource_splunk_saved_searches_test.go
+++ b/splunk/resource_splunk_saved_searches_test.go
@@ -149,7 +149,7 @@ resource "splunk_saved_searches" "test" {
 
 const newSavedSearchesWebhook = `
 resource "splunk_saved_searches" "test" {
-	name = "Test Slack Alert"
+	name = "Test Webhook Alert"
 	actions = "webhook"
 	action_webhook_param_url = "http://localhost:1234"
 	alert_comparator    = "greater than"
@@ -317,7 +317,7 @@ func TestAccSplunkSavedSearches(t *testing.T) {
 			{
 				Config: newSavedSearchesWebhook,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", "Test Slack Alert"),
+					resource.TestCheckResourceAttr(resourceName, "name", "Test Webhook Alert"),
 					resource.TestCheckResourceAttr(resourceName, "actions", "webhook"),
 					resource.TestCheckResourceAttr(resourceName, "action_webhook_param_url", "http://localhost:1234"),
 					resource.TestCheckResourceAttr(resourceName, "alert_comparator", "greater than"),

--- a/splunk/resource_splunk_saved_searches_test.go
+++ b/splunk/resource_splunk_saved_searches_test.go
@@ -147,6 +147,25 @@ resource "splunk_saved_searches" "test" {
 }
 `
 
+const newSavedSearchesWebhook = `
+resource "splunk_saved_searches" "test" {
+	name = "Test Slack Alert"
+	actions = "webhook"
+	action_webhook_param_url = "localhost:1234"
+	alert_comparator    = "greater than"
+	alert_digest_mode   = true
+	alert_expires       = "30d"
+	alert_threshold     = "0"
+	alert_type          = "number of events"
+	cron_schedule       = "*/1 * * * *"
+	disabled            = false
+	is_scheduled        = true
+	is_visible          = true
+	realtime_schedule   = true
+	search              = "index=main level=error"
+}
+`
+
 const newSavedSearchesReport = `
 resource "splunk_saved_searches" "test" {
     name = "Test Report"
@@ -282,6 +301,25 @@ func TestAccSplunkSavedSearches(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "action_slack_param_attachment", "alert_link"),
 					resource.TestCheckResourceAttr(resourceName, "action_slack_param_channel", "#channel"),
 					resource.TestCheckResourceAttr(resourceName, "action_slack_param_message", "error message"),
+					resource.TestCheckResourceAttr(resourceName, "alert_comparator", "greater than"),
+					resource.TestCheckResourceAttr(resourceName, "alert_digest_mode", "true"),
+					resource.TestCheckResourceAttr(resourceName, "alert_expires", "30d"),
+					resource.TestCheckResourceAttr(resourceName, "alert_threshold", "0"),
+					resource.TestCheckResourceAttr(resourceName, "alert_type", "number of events"),
+					resource.TestCheckResourceAttr(resourceName, "cron_schedule", "*/1 * * * *"),
+					resource.TestCheckResourceAttr(resourceName, "disabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "is_scheduled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "is_visible", "true"),
+					resource.TestCheckResourceAttr(resourceName, "realtime_schedule", "true"),
+					resource.TestCheckResourceAttr(resourceName, "search", "index=main level=error"),
+				),
+			},
+			{
+				Config: newSavedSearchesWebhook,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "Test Slack Alert"),
+					resource.TestCheckResourceAttr(resourceName, "actions", "webhook"),
+					resource.TestCheckResourceAttr(resourceName, "action_webhook_param_url", "localhost:1234"),
 					resource.TestCheckResourceAttr(resourceName, "alert_comparator", "greater than"),
 					resource.TestCheckResourceAttr(resourceName, "alert_digest_mode", "true"),
 					resource.TestCheckResourceAttr(resourceName, "alert_expires", "30d"),


### PR DESCRIPTION
Closes #80 

Used https://github.com/splunk/terraform-provider-splunk/pull/33 as a reference

This is my first time working with a Terraform provider implementation. Just out of curiosity, is there a reason the alert actions aren't their own schemas? I think this would make the saved search resource a little nicer to use eg.

```terraform
resource "splunk_saved_searches" "saved_search" {
    name = "Test New Alert"

    action_webhook {
        url: "https://my-url.com"
    }
    action_email {
        ...
    }
}
```

Also, that way the "actions" field could be inferred by the provider?