### PR TITLE
Handle missing SAML groups

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -148,7 +148,8 @@ func (c *Client) DoRequest(method string, requestURL url.URL, body interface{}) 
 	if err != nil {
 		return nil, err
 	}
-	return utils.ParseHTTPStatusCodeInResponse(response)
+
+	return response, nil
 }
 
 func (c *Client) Login() (e error) {

--- a/splunk/resource_splunk_admin_saml_groups_test.go
+++ b/splunk/resource_splunk_admin_saml_groups_test.go
@@ -41,6 +41,13 @@ func TestAccSplunkAdminSAMLGroups(t *testing.T) {
 				),
 			},
 			{
+				// to test re-creation of remotely deleted or missing resources, delete the new saml group before updating it
+				PreConfig: func() {
+					client, _ := newTestClient()
+					if _, err := client.DeleteAdminSAMLGroups("new-saml-group"); err != nil {
+						t.Error("PreConfig deletion of new-saml-group failed")
+					}
+				},
 				Config: updateAdminSAMLGroupsInput,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", "new-saml-group"),


### PR DESCRIPTION
Attempting to address #86 

This PR implements a few changes that would be needed to generally handle missing remote resources, and changes for SAML groups specifically to handle that.

If this method is considered valid and correct, additional changes may be needed to have other resource types properly handle the lack of a returned error due to a non-2XX status code before it can be merged.