### PR TITLE
adding saved event types feature

### DIFF
--- a/client/models/saved_event_types.go
+++ b/client/models/saved_event_types.go
@@ -1,0 +1,22 @@
+package models
+
+type SavedEventTypesResponse struct {
+	Entry    []SavedEventTypesEntry `json:"entry"`
+	Messages []ErrorMessage         `json:"messages"`
+}
+
+type SavedEventTypesEntry struct {
+	Name    string               `json:"name"`
+	ACL     ACLObject            `json:"acl"`
+	Content SavedEventTypeObject `json:"content"`
+}
+
+type SavedEventTypeObject struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Disabled    bool     `json:"disabled,omitempty" url:"disabled,omitempty"`
+	Color       string   `json:"color,omitempty" url:"color,omitempty"`
+	Priority    int      `json:"priority,omitempty" url:"priority,omitempty"`
+	Search      string   `json:"search,omitempty" url:"search,omitempty"`
+	Tags        []string `json:"tags,omitempty" url:"tags,omitempty"`
+}

--- a/client/saved_event_types.go
+++ b/client/saved_event_types.go
@@ -1,0 +1,69 @@
+package client
+
+import (
+	"github.com/splunk/terraform-provider-splunk/client/models"
+	"net/http"
+
+	"github.com/google/go-querystring/query"
+)
+
+func (client *Client) CreateSavedEventTypes(name, owner, app string, savedEventTypeObject *models.SavedEventTypeObject) error {
+	values, err := query.Values(savedEventTypeObject)
+	values.Add("name", name)
+	if err != nil {
+		return err
+	}
+
+	endpoint := client.BuildSplunkURL(nil, "servicesNS", owner, app, "saved", "eventtypes")
+	resp, err := client.Post(endpoint, values)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return nil
+}
+
+func (client *Client) ReadSavedEventTypes(name, owner, app string) (*http.Response, error) {
+	endpoint := client.BuildSplunkURL(nil, "servicesNS", owner, app, "saved", "eventtypes", name)
+	resp, err := client.Get(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+func (client *Client) UpdateSavedEventTypes(name string, owner string, app string, savedEventTypeObject *models.SavedEventTypeObject) error {
+	values, err := query.Values(&savedEventTypeObject)
+	if err != nil {
+		return err
+	}
+	endpoint := client.BuildSplunkURL(nil, "servicesNS", owner, app, "saved", "eventtypes", name)
+	resp, err := client.Post(endpoint, values)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return nil
+}
+
+func (client *Client) DeleteSavedEventTypes(name, owner, app string) (*http.Response, error) {
+	endpoint := client.BuildSplunkURL(nil, "servicesNS", owner, app, "saved", "eventtypes", name)
+	resp, err := client.Delete(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// services/saved/eventtypes
+func (client *Client) ReadAllSavedEventTypes() (*http.Response, error) {
+	endpoint := client.BuildSplunkURL(nil, "servicesNS", "-", "-", "saved", "eventtypes")
+	resp, err := client.Get(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}

--- a/docs/resources/saved_event_types.md
+++ b/docs/resources/saved_event_types.md
@@ -1,0 +1,38 @@
+# Resource: splunk_saved_eventtypes
+Create and manage saved searches.
+
+## Example Usage
+```
+resource "splunk_saved_event_types" "test" {
+    name        = "test"
+    description = "Test New event description"
+    disabled 	= "0"
+    priority 	= 1
+    search 		= "index=main"
+    color		= "blue"
+    tags 		= "tag"
+    acl {
+      owner = "admin"
+      sharing = "app"
+      app = "launcher"
+    }
+}
+```
+
+## Argument Reference
+For latest resource argument reference: https://docs.splunk.com/Documentation/Splunk/latest/RESTREF/RESTknowledge#saved.2Feventtypes
+
+This resource block supports the following arguments:
+* `name` - (Required) A name for the event type.
+* `description` - (Optional) Human-readable description of this event type.
+* `search` - (Required) Event type search string.
+* `color`- (Optional) Color for this event type. The supported colors are: none, et_blue, et_green, et_magenta, et_orange, et_purple, et_red, et_sky, et_teal, et_yellow.
+* `disabled` - (Optional) If True, disables the event type.
+* `priority` - (Optional) Specify an integer from 1 to 10 for the value used to determine the order in which the matching event types of an event are displayed. 1 is the highest priority.
+* `tags` - (Optional) [Deprecated] Use tags.conf.spec file to assign tags to groups of events with related field values.
+* `acl` - (Optional) The app/user context that is the namespace for the resource
+
+## Attribute Reference
+In addition to all arguments above, This resource block exports the following arguments:
+
+* `id` - The ID of the saved search event type

--- a/splunk/provider.go
+++ b/splunk/provider.go
@@ -94,6 +94,7 @@ func providerResources() map[string]*schema.Resource {
 		"splunk_indexes":                     index(),
 		"splunk_configs_conf":                configsConf(),
 		"splunk_data_ui_views":               splunkDashboards(),
+		"splunk_saved_event_types":           savedEventTypes(),
 	}
 }
 

--- a/splunk/resource_splunk_saved_event_types.go
+++ b/splunk/resource_splunk_saved_event_types.go
@@ -1,0 +1,246 @@
+package splunk
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/splunk/terraform-provider-splunk/client/models"
+)
+
+func savedEventTypes() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Saved event type name",
+			},
+			"search": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Search terms for this event type.",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Human-readable description of this event type",
+			},
+			"disabled": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "If True, disables the event type",
+			},
+			"color": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Color for this event type. The supported colors are: none, et_blue, et_green, et_magenta, et_orange, et_purple, et_red, et_sky, et_teal, et_yellow.",
+			},
+			"priority": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Specifies the order in which matching event types are displayed for an event. 1 is the highest, and 10 is the lowest.",
+			},
+			"tags": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "[Deprecated] Use tags.conf.spec file to assign tags to groups of events with related field values. ",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"acl": aclSchema(),
+		},
+		Create: savedEventTypesCreate,
+		Read:   savedEventTypesRead,
+		Update: savedEventTypesUpdate,
+		Delete: savedEventTypesDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+	}
+}
+
+func savedEventTypesCreate(d *schema.ResourceData, meta interface{}) error {
+	provider := meta.(*SplunkProvider)
+	name := d.Get("name").(string)
+	savedEventTypeConfig := getSavedEventTypeConfig(d)
+	aclObject := &models.ACLObject{}
+	if r, ok := d.GetOk("acl"); ok {
+		aclObject = getACLConfig(r.([]interface{}))
+	} else {
+		aclObject.App = "search"
+		aclObject.Owner = "nobody"
+	}
+	err := (*provider.Client).CreateSavedEventTypes(name, aclObject.Owner, aclObject.App, savedEventTypeConfig)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := d.GetOk("acl"); ok {
+		err := (*provider.Client).UpdateAcl(aclObject.Owner, aclObject.App, name, aclObject, "saved", "eventtypes")
+		if err != nil {
+			return err
+		}
+	}
+
+	d.SetId(name)
+	return savedEventTypesRead(d, meta)
+}
+
+func savedEventTypesRead(d *schema.ResourceData, meta interface{}) error {
+	provider := meta.(*SplunkProvider)
+
+	name := d.Id()
+	// We first get list of searches to get owner and app name for the specific input
+	resp, err := (*provider.Client).ReadAllSavedEventTypes()
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	entry, err := getSavedEventTypeConfigByName(name, resp)
+	if err != nil {
+		return err
+	}
+
+	if entry == nil {
+		return fmt.Errorf("Unable to find resource: %v", name)
+	}
+
+	// Now we read the configuration with proper owner and app
+	resp, err = (*provider.Client).ReadSavedEventTypes(name, entry.ACL.Owner, entry.ACL.App)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	entry, err = getSavedEventTypeConfigByName(name, resp)
+	if err != nil {
+		return err
+	}
+
+	if entry == nil {
+		return fmt.Errorf("Unable to find resource: %v", name)
+	}
+
+	if err = d.Set("name", d.Id()); err != nil {
+		return err
+	}
+	if err = d.Set("description", entry.Content.Description); err != nil {
+		return err
+	}
+	if err = d.Set("disabled", entry.Content.Disabled); err != nil {
+		return err
+	}
+	if err = d.Set("color", entry.Content.Color); err != nil {
+		return err
+	}
+	if err = d.Set("priority", entry.Content.Priority); err != nil {
+		return err
+	}
+	if err = d.Set("search", entry.Content.Search); err != nil {
+		return err
+	}
+
+	if err = d.Set("tags", entry.Content.Tags); err != nil {
+		return err
+	}
+
+	err = d.Set("acl", flattenACL(&entry.ACL))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func savedEventTypesUpdate(d *schema.ResourceData, meta interface{}) error {
+	provider := meta.(*SplunkProvider)
+	savedEventTypesConfig := getSavedEventTypeConfig(d)
+	aclObject := getACLConfig(d.Get("acl").([]interface{}))
+
+	// Update will create a new resource with private `user` permissions if resource had shared permissions set
+	var owner string
+	if aclObject.Sharing != "user" {
+		owner = "nobody"
+	} else {
+		owner = aclObject.Owner
+	}
+
+	err := (*provider.Client).UpdateSavedEventTypes(d.Id(), owner, aclObject.App, savedEventTypesConfig)
+	if err != nil {
+		return err
+	}
+
+	// Update ACL
+	err = (*provider.Client).UpdateAcl(owner, aclObject.App, d.Id(), aclObject, "saved", "eventtypes")
+	if err != nil {
+		return err
+	}
+
+	return savedEventTypesRead(d, meta)
+}
+
+func savedEventTypesDelete(d *schema.ResourceData, meta interface{}) error {
+	provider := meta.(*SplunkProvider)
+	aclObject := getACLConfig(d.Get("acl").([]interface{}))
+	resp, err := (*provider.Client).DeleteSavedEventTypes(d.Id(), aclObject.Owner, aclObject.App)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case 200, 201:
+		return nil
+
+	default:
+		errorResponse := &models.InputsUDPResponse{}
+		_ = json.NewDecoder(resp.Body).Decode(errorResponse)
+		err := errors.New(errorResponse.Messages[0].Text)
+		return err
+	}
+}
+
+func getSavedEventTypeConfig(d *schema.ResourceData) (savedEventTypeObj *models.SavedEventTypeObject) {
+	savedEventTypeObj = &models.SavedEventTypeObject{
+		Description: d.Get("description").(string),
+		Disabled:    d.Get("disabled").(bool),
+		Color:       d.Get("color").(string),
+		Priority:    d.Get("priority").(int),
+		Search:      d.Get("search").(string),
+	}
+
+	if val, ok := d.GetOk("tags"); ok {
+		for _, v := range val.([]interface{}) {
+			savedEventTypeObj.Tags = append(savedEventTypeObj.Tags, v.(string))
+		}
+	}
+
+	return savedEventTypeObj
+}
+
+func getSavedEventTypeConfigByName(name string, httpResponse *http.Response) (savedEventTypesEntry *models.SavedEventTypesEntry, err error) {
+	response := &models.SavedEventTypesResponse{}
+	switch httpResponse.StatusCode {
+	case 200, 201:
+		_ = json.NewDecoder(httpResponse.Body).Decode(&response)
+		re := regexp.MustCompile(`(.*)`)
+		for _, entry := range response.Entry {
+			if name == re.FindStringSubmatch(entry.Name)[1] {
+				return &entry, nil
+			}
+		}
+
+	default:
+		_ = json.NewDecoder(httpResponse.Body).Decode(response)
+		err := errors.New(response.Messages[0].Text)
+		return savedEventTypesEntry, err
+	}
+
+	return savedEventTypesEntry, nil
+}

--- a/splunk/resource_splunk_saved_event_types_test.go
+++ b/splunk/resource_splunk_saved_event_types_test.go
@@ -1,0 +1,73 @@
+package splunk
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"net/http"
+	"testing"
+)
+
+const newSavedEventTypes = `
+resource "splunk_saved_event_types" "event-type" {
+    name 		= "test"
+    description = "Test New event description"
+    disabled 	= "0"
+    priority 	= 1
+    search 		= "index=main"
+    color		= "blue"
+    tags 		= "tag"
+    acl {
+      owner = "admin"
+      sharing = "app"
+      app = "launcher"
+    }
+}
+`
+
+func TestAccSplunkSavedEventTypes(t *testing.T) {
+	resourceName := "splunk_saved_event_types.test"
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		CheckDestroy: testAccSplunkSavedEventsDestroyResources,
+		Steps: []resource.TestStep{
+			{
+				Config: newSavedEventTypes,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "test"),
+					resource.TestCheckResourceAttr(resourceName, "search", "index=main"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Test New event description"),
+					resource.TestCheckResourceAttr(resourceName, "disabled", "0"),
+					resource.TestCheckResourceAttr(resourceName, "priority", "1"),
+					resource.TestCheckResourceAttr(resourceName, "color", "blue"),
+					resource.TestCheckResourceAttr(resourceName, "tags", "tag"),
+				),
+			},
+			{
+				ResourceName:      "splunk_saved_event_types.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccSplunkSavedEventsDestroyResources(s *terraform.State) error {
+	client, err := newTestClient()
+	if err != nil {
+		return err
+	}
+	for _, rs := range s.RootModule().Resources {
+		switch rs.Type {
+		case "splunk_saved_event_types":
+			endpoint := client.BuildSplunkURL(nil, "servicesNS", "nobody", "search", "saved", "eventtypes", rs.Primary.ID)
+			resp, err := client.Get(endpoint)
+			if resp.StatusCode != http.StatusNotFound {
+				return fmt.Errorf("error: %s: %s", rs.Primary.ID, err)
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
# Resource: splunk_saved_eventtypes
Create and manage saved searches.

## Example Usage
```
resource "splunk_saved_event_types" "test" {
    name        = "test"
    description = "Test New event description"
    disabled 	= "0"
    priority 	= 1
    search 		= "index=main"
    color		= "blue"
    tags 		= "tag"
    acl {
      owner = "admin"
      sharing = "app"
      app = "launcher"
    }
}
```

## Argument Reference
For latest resource argument reference: https://docs.splunk.com/Documentation/Splunk/latest/RESTREF/RESTknowledge#saved.2Feventtypes

This resource block supports the following arguments:
* `name` - (Required) A name for the event type.
* `description` - (Optional) Human-readable description of this event type.
* `search` - (Required) Event type search string.
* `color`- (Optional) Color for this event type. The supported colors are: none, et_blue, et_green, et_magenta, et_orange, et_purple, et_red, et_sky, et_teal, et_yellow.
* `disabled` - (Optional) If True, disables the event type.
* `priority` - (Optional) Specify an integer from 1 to 10 for the value used to determine the order in which the matching event types of an event are displayed. 1 is the highest priority.
* `tags` - (Optional) [Deprecated] Use tags.conf.spec file to assign tags to groups of events with related field values.
* `acl` - (Optional) The app/user context that is the namespace for the resource

## Attribute Reference
In addition to all arguments above, This resource block exports the following arguments:

* `id` - The ID of the saved search event type
