### PR TITLE
#105 splunk_data_ui_views - Don't read all views

### DIFF
--- a/client/data_ui_views.go
+++ b/client/data_ui_views.go
@@ -59,13 +59,3 @@ func (client *Client) DeleteDashboardObject(owner string, app string, name strin
 
 	return resp, nil
 }
-
-func (client *Client) ReadAllDashboardObject() (*http.Response, error) {
-	endpoint := client.BuildSplunkURL(nil, "servicesNS", "-", "-", "data", "ui", "views")
-	resp, err := client.Get(endpoint)
-	if err != nil {
-		return nil, err
-	}
-
-	return resp, nil
-}


### PR DESCRIPTION
Closes #105 

This PR attempts to improve the performance of the `splunk_data_ui_views` resource during the read phase.

The current implementation first reads all views (`servicesNS/-/-/data/ui/views`) and iterates through the found views for the first view with a name matching the resource's name. This method is flawed for two major reasons:

* Asking for all views in all namespaces is likely to return a very large number of results, and the request itself is likely to take a long time to complete.
* The list of returned views may very well contain multiple views with the same name as the resource. Without also matching the namespace (app/user), there's a non-negligible chance that the wrong view would be the one returned.

These issues are addressed in this pull request by:

* No longer reading all dashboard objects
* Using the found or pseudo-default ACL configuration for all actions (create, read, update, delete).

Output from related acceptance tests:

```
TF_ACC=1 <redacted> go test ./... -timeout 30s -run TestAccSplunkDashboards -v        
...
=== RUN   TestAccSplunkDashboards
--- PASS: TestAccSplunkDashboards (0.26s)
=== RUN   TestAccSplunkDashboardsWithAcl
--- PASS: TestAccSplunkDashboardsWithAcl (0.25s)
PASS
ok      github.com/splunk/terraform-provider-splunk/splunk      0.919s
```