### PR TITLE
allow M1 builds on Github Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.16
       -
         name: Import GPG key
         id: import_gpg


### PR DESCRIPTION
Currently the build/release process uses go version 1.14 to build the binaries, where there is no support for M1 Macs.
This tiny update bumps the go version number to 1.16 to allow builds for `darwin_arm64` targets.