### PR TITLE
allow-underscore-in-configs-conf-name

### DIFF
--- a/splunk/resource_splunk_configs_conf.go
+++ b/splunk/resource_splunk_configs_conf.go
@@ -31,7 +31,7 @@ func configsConf() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9\-.]+/[a-zA-Z0-9\-.]+`), "A '/' separated string consisting of {conf_file_name}/{stanza_name} ex. props/custom_stanza"),
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9_\-.]+/[a-zA-Z0-9_\-.]+`), "A '/' separated string consisting of {conf_file_name}/{stanza_name} ex. props/custom_stanza"),
 				Description:  `A '/' separated string consisting of {conf_file_name}/{stanza_name} ex. props/custom_stanza`,
 			},
 			"acl": aclSchema(),

--- a/splunk/resource_splunk_configs_conf_test.go
+++ b/splunk/resource_splunk_configs_conf_test.go
@@ -19,7 +19,7 @@ resource "splunk_configs_conf" "tf_test-stanza" {
 `
 
 const updateConfigsConf = `
-resource "splunk_configs_conf" "tf_test-stanza" {
+resource "splunk_configs_conf" "tftest-stanza" {
 	name = "tf_test/tftest_stanza"
 	variables = {
         "disabled": "false"

--- a/splunk/resource_splunk_configs_conf_test.go
+++ b/splunk/resource_splunk_configs_conf_test.go
@@ -52,7 +52,7 @@ func TestAccCreateSplunkConfigsConf(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "splunk_configs_conf.tf_test-stanza",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},

--- a/splunk/resource_splunk_configs_conf_test.go
+++ b/splunk/resource_splunk_configs_conf_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 const newConfigsConf = `
-resource "splunk_configs_conf" "tf_test-stanza" {
+resource "splunk_configs_conf" "tftest-stanza" {
 	name = "tf_test/tftest_stanza"
 	variables = {
         "disabled": "false"

--- a/splunk/resource_splunk_configs_conf_test.go
+++ b/splunk/resource_splunk_configs_conf_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 const newConfigsConf = `
-resource "splunk_configs_conf" "tftest-stanza" {
-	name = "tftest/tftest_stanza"
+resource "splunk_configs_conf" "tf_test-stanza" {
+	name = "tf_test/tftest_stanza"
 	variables = {
         "disabled": "false"
 		"key": "value"
@@ -19,8 +19,8 @@ resource "splunk_configs_conf" "tftest-stanza" {
 `
 
 const updateConfigsConf = `
-resource "splunk_configs_conf" "tftest-stanza" {
-	name = "tftest/tftest_stanza"
+resource "splunk_configs_conf" "tf_test-stanza" {
+	name = "tf_test/tftest_stanza"
 	variables = {
         "disabled": "false"
 		"key": "new-value"
@@ -52,7 +52,7 @@ func TestAccCreateSplunkConfigsConf(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "splunk_configs_conf.tftest-stanza",
+				ResourceName:      "splunk_configs_conf.tf_test-stanza",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},


### PR DESCRIPTION
Without this fix, provider does not allow create configuration with underscore in name
Example:
```
resource "splunk_configs_conf" "db_connection" {
  name = "db_connections/terraform-connection" ### this is the issue!
  variables = {
    connection_type : "oracle"
    database : "my-db"
    host : "example.com"
    port : 1521
    identity : "terraform-identity"
    timezone : "Israel"
  }
}
```
terraform apply on master:  
```
│ Error: invalid value for name (A '/' separated string consisting of {conf_file_name}/{stanza_name} ex. props/custom_stanza)
│
│   with splunk_configs_conf.db_connection,
│   on main.tf line 85, in resource "splunk_configs_conf" "db_connection":
│   85: resource "splunk_configs_conf" "db_connection" {
│
```
terraform apply on this branch: 
it works, db_connection created