### PR TITLE
splunk_indexes type fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+##1.5.0
+
+**WARNING: POTENTIAL BREAKING CHANGES**
+* Change splunk_indexes field types:
+    * bucket_rebuild_memory_hint - Int
+    * max_hot_buckets - String
+    * rep_factor - Int
+
+These settings must be changed to be of the correct type in the Terraform configuration. They were the incorrect type previously, and as such their values were never updated during state refresh.
+
+* Deprecated splunk_indexes field `rep_factor`
+
 ##1.4.12
 * FIx: Don't read all searches just to find one search
 

--- a/client/models/index.go
+++ b/client/models/index.go
@@ -13,7 +13,7 @@ type IndexEntry struct {
 
 type IndexObject struct {
 	BlockSignSize                 int    `json:"blockSignSize,omitempty" url:"blockSignSize,omitempty"`
-	BucketRebuildMemoryHint       string `json:"bucketRebuildMemoryHint,omitempty" url:"bucketRebuildMemoryHint,omitempty"`
+	BucketRebuildMemoryHint       int    `json:"bucketRebuildMemoryHint,omitempty" url:"bucketRebuildMemoryHint,omitempty"`
 	ColdPath                      string `json:"coldPath,omitempty" url:"coldPath,omitempty"`
 	ColdToFrozenDir               string `json:"coldToFrozenDir,omitempty" url:"coldToFrozenDir,omitempty"`
 	ColdToFrozenScript            string `json:"coldToFrozenScript,omitempty" url:"coldToFrozenScript,omitempty"`
@@ -25,7 +25,7 @@ type IndexObject struct {
 	MaxBloomBackfillBucketAge     string `json:"maxBloomBackfillBucketAge,omitempty" url:"maxBloomBackfillBucketAge,omitempty"`
 	MaxConcurrentOptimizes        int    `json:"maxConcurrentOptimizes,omitempty" url:"maxConcurrentOptimizes,omitempty"`
 	MaxDataSize                   string `json:"maxDataSize,omitempty" url:"maxDataSize,omitempty"`
-	MaxHotBuckets                 int    `json:"maxHotBuckets,omitempty" url:"maxHotBuckets,omitempty"`
+	MaxHotBuckets                 string `json:"maxHotBuckets,omitempty" url:"maxHotBuckets,omitempty"`
 	MaxHotIdleSecs                int    `json:"maxHotIdleSecs,omitempty" url:"maxHotIdleSecs,omitempty"`
 	MaxHotSpanSecs                int    `json:"maxHotSpanSecs,omitempty" url:"maxHotSpanSecs,omitempty"`
 	MaxMemMB                      int    `json:"maxMemMB,omitempty" url:"maxMemMB,omitempty"`
@@ -41,7 +41,7 @@ type IndexObject struct {
 	QuarantineFutureSecs          int    `json:"quarantineFutureSecs,omitempty" url:"quarantineFutureSecs,omitempty"`
 	QuarantinePastSecs            int    `json:"quarantinePastSecs,omitempty" url:"quarantinePastSecs,omitempty"`
 	RawChunkSizeBytes             int    `json:"rawChunkSizeBytes,omitempty" url:"rawChunkSizeBytes,omitempty"`
-	RepFactor                     string `json:"repFactor,omitempty" url:"repFactor,omitempty"`
+	RepFactor                     int    `json:"repFactor,omitempty" url:"repFactor,omitempty"`
 	RotatePeriodInSecs            int    `json:"rotatePeriodInSecs,omitempty" url:"rotatePeriodInSecs,omitempty"`
 	ServiceMetaPeriod             int    `json:"serviceMetaPeriod,omitempty" url:"serviceMetaPeriod,omitempty"`
 	SyncMeta                      bool   `json:"syncMeta,omitempty" url:"syncMeta,omitempty"`

--- a/docs/resources/indexes.md
+++ b/docs/resources/indexes.md
@@ -87,9 +87,15 @@ To disable, set to 0, but this is NOT recommended. Highest legal value is 214748
                                         This is a mechanism to prevent main hot buckets from being polluted with fringe events.
 * `quarantine_past_secs` - (Optional) Events with timestamp of quarantinePastSecs older than "now" are dropped into quarantine bucket. Defaults to 77760000 (900 days). This is a mechanism to prevent the main hot buckets from being polluted with fringe events.
 * `raw_chunk_size_bytes` - (Optional) Target uncompressed size in bytes for individual raw slice in the rawdata journal of the index. Defaults to 131072 (128KB). 0 is not a valid value. If 0 is specified, rawChunkSizeBytes is set to the default value.
-* `rep_factor` - (Optional) Index replication control. This parameter applies to only clustering slaves.
+* `rep_factor` - (Deprecated, Optional) Index replication control. This parameter applies to only clustering slaves.
                             auto = Use the master index replication configuration value.
                             0 = Turn off replication for this index.
+
+  `rep_factor` is deprecated in this Terraform Provider.
+				
+  The REST API returns a 0 for both `repFactor = 0` and `repFactor = auto`. These are the two valid values for `repFactor`, yet they cannot be detected as different from the API's response.
+				
+  Additionally, `repFactor` only has meaning on clustered indexes, which should be configured by the Indexer Cluster Manager, not via REST.
 * `rotate_period_in_secs` - (Optional) How frequently (in seconds) to check if a new hot bucket needs to be created. Also, how frequently to check if there are any warm/cold buckets that should be rolled/frozen.
 * `service_meta_period` - (Optional) Defines how frequently metadata is synced to disk, in seconds. Defaults to 25 (seconds).
                                      You may want to set this to a higher value if the sum of your metadata file sizes is larger than many tens of megabytes, to avoid the hit on I/O in the indexing fast path.

--- a/splunk/resource_splunk_indexes.go
+++ b/splunk/resource_splunk_indexes.go
@@ -287,6 +287,11 @@ func index() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Computed: true,
+				Deprecated: `rep_factor is deprecated in this Terraform Provider.
+				
+				The REST API returns a 0 for both "repFactor = 0" and "repFactor = auto". These are the two valid values for repFactor, yet they cannot be detected as different from the API's response.
+				
+				Additionally, repFactor only has meaning on clustered indexes, which should be configured by the Indexer Cluster Manager, not via REST.`,
 				Description: `Index replication control. This parameter applies to only clustering slaves.
 				auto = Use the master index replication configuration value.
 

--- a/splunk/resource_splunk_indexes.go
+++ b/splunk/resource_splunk_indexes.go
@@ -24,7 +24,7 @@ func index() *schema.Resource {
 				A recommended value is 100.`,
 			},
 			"bucket_rebuild_memory_hint": {
-				Type:     schema.TypeString,
+				Type:     schema.TypeInt,
 				Optional: true,
 				Computed: true,
 				Description: `Suggestion for the bucket rebuild process for the size of the time-series (tsidx) file to make.
@@ -146,7 +146,7 @@ func index() *schema.Resource {
 				Note: The precise size of your warm buckets may vary from maxDataSize, due to post-processing and timing issues with the rolling policy.`,
 			},
 			"max_hot_buckets": {
-				Type:     schema.TypeInt,
+				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 				Description: `Maximum hot buckets that can exist per index. Defaults to 3.
@@ -284,7 +284,7 @@ func index() *schema.Resource {
 				WARNING: This is an advanced parameter. Only change it if you are instructed to do so by Splunk Support.`,
 			},
 			"rep_factor": {
-				Type:     schema.TypeString,
+				Type:     schema.TypeInt,
 				Optional: true,
 				Computed: true,
 				Description: `Index replication control. This parameter applies to only clustering slaves.
@@ -628,7 +628,7 @@ func indexDelete(d *schema.ResourceData, meta interface{}) error {
 func getIndexConfig(d *schema.ResourceData) (indexConfigObject *models.IndexObject) {
 	indexConfigObject = &models.IndexObject{}
 	indexConfigObject.BlockSignSize = d.Get("block_sign_size").(int)
-	indexConfigObject.BucketRebuildMemoryHint = d.Get("bucket_rebuild_memory_hint").(string)
+	indexConfigObject.BucketRebuildMemoryHint = d.Get("bucket_rebuild_memory_hint").(int)
 	indexConfigObject.ColdPath = d.Get("cold_path").(string)
 	indexConfigObject.ColdToFrozenDir = d.Get("cold_to_frozen_dir").(string)
 	indexConfigObject.ColdToFrozenScript = d.Get("cold_to_frozen_script").(string)
@@ -640,7 +640,7 @@ func getIndexConfig(d *schema.ResourceData) (indexConfigObject *models.IndexObje
 	indexConfigObject.MaxBloomBackfillBucketAge = d.Get("max_bloom_backfill_bucket_age").(string)
 	indexConfigObject.MaxConcurrentOptimizes = d.Get("max_concurrent_optimizes").(int)
 	indexConfigObject.MaxDataSize = d.Get("max_data_size").(string)
-	indexConfigObject.MaxHotBuckets = d.Get("max_hot_buckets").(int)
+	indexConfigObject.MaxHotBuckets = d.Get("max_hot_buckets").(string)
 	indexConfigObject.MaxHotIdleSecs = d.Get("max_hot_idle_secs").(int)
 	indexConfigObject.MaxHotSpanSecs = d.Get("max_hot_span_secs").(int)
 	indexConfigObject.MaxMemMB = d.Get("max_mem_mb").(int)
@@ -656,7 +656,7 @@ func getIndexConfig(d *schema.ResourceData) (indexConfigObject *models.IndexObje
 	indexConfigObject.QuarantineFutureSecs = d.Get("quarantine_future_secs").(int)
 	indexConfigObject.QuarantinePastSecs = d.Get("quarantine_past_secs").(int)
 	indexConfigObject.RawChunkSizeBytes = d.Get("raw_chunk_size_bytes").(int)
-	indexConfigObject.RepFactor = d.Get("rep_factor").(string)
+	indexConfigObject.RepFactor = d.Get("rep_factor").(int)
 	indexConfigObject.RotatePeriodInSecs = d.Get("rotate_period_in_secs").(int)
 	indexConfigObject.ServiceMetaPeriod = d.Get("service_meta_period").(int)
 	indexConfigObject.SyncMeta = d.Get("sync_meta").(bool)

--- a/splunk/resource_splunk_indexes.go
+++ b/splunk/resource_splunk_indexes.go
@@ -615,7 +615,10 @@ func indexDelete(d *schema.ResourceData, meta interface{}) error {
 
 	default:
 		errorResponse := &models.IndexResponse{}
-		_ = json.NewDecoder(resp.Body).Decode(errorResponse)
+		if err := json.NewDecoder(resp.Body).Decode(errorResponse); err != nil {
+			return err
+		}
+
 		err := errors.New(errorResponse.Messages[0].Text)
 		return err
 	}
@@ -668,7 +671,9 @@ func getIndexConfigByName(name string, httpResponse *http.Response) (indexEntry 
 	response := &models.IndexResponse{}
 	switch httpResponse.StatusCode {
 	case 200, 201:
-		_ = json.NewDecoder(httpResponse.Body).Decode(&response)
+		if err := json.NewDecoder(httpResponse.Body).Decode(&response); err != nil {
+			return nil, err
+		}
 		re := regexp.MustCompile(`(.*)`)
 		for _, entry := range response.Entry {
 			if name == re.FindStringSubmatch(entry.Name)[1] {


### PR DESCRIPTION
This PR updates the `splunk_indexes` resource to use the proper types, as defined by what is returned by the Splunk REST API.

While the REST documentation states that `bucketRebuildMemoryHint` and `repFactor` can be set by string value, they are always _returned_ by the REST API as integers.

Additionally, `repFactor` is returned as `0` when the index is configured for both `repFactor = 0` and `repFactor = auto`, making it impossible to differentiate between the two configured values. Because of this failure, and because that setting is only really valid on clustered indexes which should be configured by the Indexer Cluster Manager anyway, I've deprecated `repFactor`.

These failures went unnoticed because JSON unmarshaling errors were ignored. The first commit in this PR handles errors returned when unmarshaling Index data, which otherwise triggers failing tests.