### PR TITLE
saved_search: auto_summarize omit when empty

### DIFF
--- a/client/models/saved_searches.go
+++ b/client/models/saved_searches.go
@@ -101,7 +101,7 @@ type SavedSearchObject struct {
 	AlertThreshold                     string  `json:"alert_threshold,omitempty" url:"alert_threshold,omitempty"`
 	AlertType                          string  `json:"alert_type,omitempty" url:"alert_type,omitempty"`
 	AllowSkew                          string  `json:"allow_skew,omitempty" url:"allow_skew,omitempty"`
-	AutoSummarize                      bool    `json:"auto_summarize" url:"auto_summarize"`
+	AutoSummarize                      bool    `json:"auto_summarize,omitempty" url:"auto_summarize,omitempty"`
 	AutoSummarizeCommand               string  `json:"auto_summarize.command,omitempty" url:"auto_summarize.command,omitempty"`
 	AutoSummarizeCronSchedule          string  `json:"auto_summarize.cron_schedule,omitempty" url:"auto_summarize.cron_schedule,omitempty"`
 	AutoSummarizeDispatchEarliestTime  string  `json:"auto_summarize.dispatch.earliest_time,omitempty" url:"auto_summarize.dispatch.earliest_time,omitempty"`


### PR DESCRIPTION
When trying to create saved searches for Splunk Cloud, the auto_summarize field, even when not set, has a default value set. Having the field set results in a 400 response as the auto_summarize parameter does not seem to be handled by Splunk Cloud. Omitting the field when empty allows the saved search to be properly created and is defaulted to false regardless on if the field is set by default.