### PR TITLE
Don't override count value if passed to BuildSplunkURL

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -83,7 +83,11 @@ func (c *Client) BuildSplunkURL(queryValues url.Values, urlPathParts ...string) 
 	}
 
 	queryValues.Set("output_mode", "json")
-	queryValues.Set("count", "-1") // To avoid http response truncation
+	
+	if !queryValues.Has("count") {
+		queryValues.Set("count", "-1") // To avoid http response truncation
+	}
+	
 	httpScheme := getEnv(envVarHTTPScheme, defaultScheme)
 
 	return url.URL{


### PR DESCRIPTION
BuildSplunkURL defaults count to -1, it should not override count if passed in queryValues.