### PR TITLE
Saved search update handler doesn't support schedule_priority

### DIFF
--- a/client/saved_searches.go
+++ b/client/saved_searches.go
@@ -1,8 +1,9 @@
 package client
 
 import (
-	"github.com/splunk/terraform-provider-splunk/client/models"
 	"net/http"
+
+	"github.com/splunk/terraform-provider-splunk/client/models"
 
 	"github.com/google/go-querystring/query"
 )
@@ -34,6 +35,9 @@ func (client *Client) ReadSavedSearches(name, owner, app string) (*http.Response
 }
 
 func (client *Client) UpdateSavedSearches(name string, owner string, app string, savedSearchObject *models.SavedSearchObject) error {
+	// Splunk API doesn't update the saved search when the schedule_priority field is set (BUG)
+	// As a workaround we can unset SchedulePriority in update requests, since updating this tf field forces new resource creation
+	savedSearchObject.SchedulePriority = ""
 	values, err := query.Values(&savedSearchObject)
 	if err != nil {
 		return err

--- a/splunk/resource_splunk_saved_searches.go
+++ b/splunk/resource_splunk_saved_searches.go
@@ -1052,6 +1052,7 @@ func savedSearches() *schema.Resource {
 			},
 			"schedule_priority": {
 				Type:        schema.TypeString,
+				ForceNew:    true,
 				Optional:    true,
 				Computed:    true,
 				Description: "Raises the scheduling priority of the named search. Defaults to Default",


### PR DESCRIPTION
API requests to update saved searches don't actually update the saved search when the schedule_priority field is set.  As a workaround we can remove this field from update requests & instead force new resource creation when this field is updated.

#2 