### PR TITLE
Parsing HEC's UseACK by int, bool and string

### DIFF
--- a/client/models/http_event_collector.go
+++ b/client/models/http_event_collector.go
@@ -1,5 +1,11 @@
 package models
 
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
 // HTTP Input Response Schema
 type HECResponse struct {
 	Entry    []HECEntry     `json:"entry"`
@@ -20,5 +26,83 @@ type HttpEventCollectorObject struct {
 	SourceType string        `json:"sourcetype,omitempty" url:"sourcetype,omitempty"`
 	Token      string        `json:"token,omitempty" url:"token,omitempty"`
 	Disabled   bool          `json:"disabled,omitempty" url:"disabled"`
-	UseACK     int           `json:"useACK,string,omitempty" url:"useACK"`
+	UseACK     int           `json:"useACK,omitempty" url:"useACK"`
+}
+
+func (a *HttpEventCollectorObject) UnmarshalJSON(data []byte) error {
+	var content map[string]interface{}
+	err := json.Unmarshal(data, &content)
+
+	if err != nil {
+		return err
+	}
+
+	if host, ok := content["host"]; ok {
+		a.Host = host.(string)
+	}
+
+	if indexes, ok := content["indexes"]; ok {
+		a.Indexes = indexes.([]interface{})
+	}
+
+	if index, ok := content["index"]; ok {
+		a.Index = index.(string)
+	}
+
+	if source, ok := content["source"]; ok {
+		a.Source = source.(string)
+	}
+
+	if sourcetype, ok := content["sourcetype"]; ok {
+		a.SourceType = sourcetype.(string)
+	}
+
+	if token, ok := content["token"]; ok {
+		a.Token = token.(string)
+	}
+
+	if disabled, ok := content["disabled"]; ok {
+		a.Disabled = disabled.(bool)
+	}
+
+	if useack, ok := content["useACK"]; ok {
+		a.UseACK, err = unmarshalUseAck(useack)
+	}
+
+	return err
+}
+
+func unmarshalUseAck(data interface{}) (int, error) {
+	if i, ok := data.(int); ok {
+		return i, nil
+	}
+
+	if i, ok := data.(float64); ok {
+		return int(i), nil
+	}
+
+	if b, ok := data.(bool); ok {
+		if b {
+			return 1, nil
+		}
+		return 0, nil
+	}
+
+	if s, ok := data.(string); ok {
+		if s == "true" {
+			return 1, nil
+		}
+
+		if s == "false" {
+			return 0, nil
+		}
+
+		val, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return 0, err
+		}
+		return int(val), nil
+	}
+
+	return 0, fmt.Errorf(`Could not parse "%v" as UseAck`, data)
 }

--- a/client/models/http_event_collector_test.go
+++ b/client/models/http_event_collector_test.go
@@ -1,0 +1,172 @@
+package models
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+func randomString() string {
+	n := rand.Intn(100)
+	charset := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	sb := strings.Builder{}
+	sb.Grow(n)
+
+	for i := 0; i < n; i++ {
+		sb.WriteByte(charset[rand.Intn(len(charset))])
+	}
+
+	return sb.String()
+}
+
+func TestDecodeHttpEventCollectorObject(t *testing.T) {
+	indexes := make([]string, rand.Intn(10))
+
+	for i := range indexes {
+		indexes[i] = randomString()
+	}
+
+	host := randomString()
+	index := randomString()
+	source := randomString()
+	sourcetype := randomString()
+	token := randomString()
+
+	testCase := fmt.Sprintf(
+		`{
+			"host":"%s",
+			"indexes":["%s"],
+			"index":"%s",
+			"source":"%s",
+			"sourcetype":"%s",
+			"token":"%s",
+			"disabled":false,
+			"useACK":"1"
+		}`,
+		host,
+		strings.Join(indexes, `","`),
+		index,
+		source,
+		sourcetype,
+		token,
+	)
+
+	content := HttpEventCollectorObject{}
+	err := json.NewDecoder(strings.NewReader(testCase)).Decode(&content)
+
+	if err != nil {
+		t.Errorf("Could not parse HttpEventCollectorObject: %v", err)
+	}
+
+	if content.Host != host {
+		t.Errorf("Host did not parse %s as %s", content.Host, host)
+	}
+
+	for i := range indexes {
+		if v := content.Indexes[i]; v != indexes[i] {
+			t.Errorf("Indexes[%d] did not parse %v as %s", i, v, indexes[i])
+		}
+	}
+
+	if content.Index != index {
+		t.Errorf("Index did not parse %s as %s", content.Index, index)
+	}
+
+	if content.Source != source {
+		t.Errorf("Source did not parse %s as %s", content.Source, source)
+	}
+
+	if content.SourceType != sourcetype {
+		t.Errorf("SourceType did not parse %s as %s", content.SourceType, sourcetype)
+	}
+
+	if content.Token != token {
+		t.Errorf("Token did not parse %s as %s", content.Token, token)
+	}
+
+	if content.Disabled {
+		t.Error("Disabled should've been false")
+	}
+
+	if content.UseACK != 1 {
+		t.Errorf("UseACK did not parse %d as 1", content.UseACK)
+	}
+}
+
+func TestDecodeUseAckAsBool(t *testing.T) {
+	testCases := map[string]int{"false": 0, "true": 1}
+
+	for k, v := range testCases {
+		t.Run(fmt.Sprintf("%s should be %d", k, v), func(t *testing.T) {
+			body := fmt.Sprintf(`{"useACK":%s}`, k)
+			content := HttpEventCollectorObject{}
+			err := json.NewDecoder(strings.NewReader(body)).Decode(&content)
+
+			if err != nil {
+				t.Errorf("Could not parse useACK from bool: %v", err)
+			}
+
+			if int(content.UseACK) != v {
+				t.Errorf("UseACK did not parse %s as %d", k, v)
+			}
+		})
+	}
+}
+
+func TestDecodeUseAckAsBoolString(t *testing.T) {
+	testCases := map[string]int{"false": 0, "true": 1}
+
+	for k, v := range testCases {
+		t.Run(fmt.Sprintf("%s should be %d", k, v), func(t *testing.T) {
+			body := fmt.Sprintf(`{"useACK":"%s"}`, k)
+			content := HttpEventCollectorObject{}
+			err := json.NewDecoder(strings.NewReader(body)).Decode(&content)
+
+			if err != nil {
+				t.Errorf("Could not parse useACK from bool-string: %v", err)
+			}
+
+			if int(content.UseACK) != v {
+				t.Errorf("UseACK did not parse %s as %d", k, v)
+			}
+		})
+	}
+}
+
+func TestDecodeUseAckAsString(t *testing.T) {
+	for v := range rand.Perm(3) {
+		t.Run(fmt.Sprintf(`"%d" should be %d`, v, v), func(t *testing.T) {
+			body := fmt.Sprintf(`{"useACK":"%d"}`, v)
+			content := HttpEventCollectorObject{}
+			err := json.NewDecoder(strings.NewReader(body)).Decode(&content)
+
+			if err != nil {
+				t.Errorf("Could not parse useACK string: %v", err)
+			}
+
+			if int(content.UseACK) != v {
+				t.Errorf("UseACK did not parse %d", v)
+			}
+		})
+	}
+}
+
+func TestDecodeUseAckAsInt(t *testing.T) {
+	for v := range rand.Perm(3) {
+		t.Run(fmt.Sprintf(`%d should be %d`, v, v), func(t *testing.T) {
+			body := fmt.Sprintf(`{"useACK":%d}`, v)
+			content := HttpEventCollectorObject{}
+			err := json.NewDecoder(strings.NewReader(body)).Decode(&content)
+
+			if err != nil {
+				t.Errorf("Could not parse useACK from int: %v", err)
+			}
+
+			if int(content.UseACK) != v {
+				t.Errorf("UseACK did not parse %d", v)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Resolves #130 by parsing multiple different types of data in the `useACK`field.

In our Cloud environment, this field comes as a stringified boolean, such as a `"false"`. Which caused an error as the string wasn't able to be parsed into an `int`.

These changes will cope with `useACK` as both `int` and `bool` by using a custom json-marshaller ...

* `int` as a `string`: `"1"`
* `int` as an `int`: `1`
* `bool` as a `string`: `"true"`
* `bool` as a `bool`: `true`

There's test cases for all these variants.