### PR TITLE
Check response status code for errors

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
@@ -147,6 +148,16 @@ func (c *Client) DoRequest(method string, requestURL url.URL, body interface{}) 
 	response, err := c.Do(request)
 	if err != nil {
 		return nil, err
+	}
+	if response == nil {
+		return nil, fmt.Errorf("nil response for '%s' request", &requestURL)
+	}
+	if response.StatusCode != 200 && response.StatusCode != 201 {
+		body, err := ioutil.ReadAll(response.Body)
+		if err != nil {
+			return nil, err
+		}
+		return response, fmt.Errorf("%s: %s", response.Status, string(body))
 	}
 
 	return response, nil

--- a/splunk/resource_splunk_admin_saml_groups_test.go
+++ b/splunk/resource_splunk_admin_saml_groups_test.go
@@ -41,13 +41,6 @@ func TestAccSplunkAdminSAMLGroups(t *testing.T) {
 				),
 			},
 			{
-				// to test re-creation of remotely deleted or missing resources, delete the new saml group before updating it
-				PreConfig: func() {
-					client, _ := newTestClient()
-					if _, err := client.DeleteAdminSAMLGroups("new-saml-group"); err != nil {
-						t.Error("PreConfig deletion of new-saml-group failed")
-					}
-				},
 				Config: updateAdminSAMLGroupsInput,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", "new-saml-group"),

--- a/splunk/resource_splunk_saved_searches.go
+++ b/splunk/resource_splunk_saved_searches.go
@@ -58,9 +58,9 @@ func savedSearches() *schema.Resource {
 					"4 - Warning",
 			},
 			"action_snow_event_param_description": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
 				Description: "	A brief description of the event.",
 			},
 			"action_snow_event_param_ci_identifier": {


### PR DESCRIPTION
We don't check the response for errors when making API calls. Currently if the API returns a non 200 or 201 we ignore the error and terraform errors out with `Could not find object id=...` because it could not find the desired output in the response. This leaves the state file in a bad state to make any further changes. This change will propagate the error properly back to the user and not leave the state file broken.

Before:
```
2023-06-21T16:34:30.160-0400 [ERROR] vertex "module.lookup_testing_1.splunk_saved_searches.lookup_template" error: Could not find object id=test search
╷
│ Error: Could not find object id=test search
│
│   with module.lookup_testing_1.splunk_saved_searches.lookup_template,
│   on ../../../modules/lookup_template/main.tf line 1, in resource "splunk_saved_searches" "lookup_template":
│    1: resource "splunk_saved_searches" "lookup_template" {
│
╵
2023-06-21T16:34:30.184-0400 [DEBUG] provider.stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = error reading from server: EOF"
```

After fix:
```
2023-06-22T09:13:00.109-0400 [ERROR] vertex "module.lookup_testing_1.splunk_saved_searches.lookup_template" error: 400 Bad Request: {"messages":[{"type":"ERROR","text":"windowed real-time per result alerts require field based alert throttling to be enabled"}]}
╷
│ Error: 400 Bad Request: {"messages":[{"type":"ERROR","text":"windowed real-time per result alerts require field based alert throttling to be enabled"}]}
│
│   with module.lookup_testing_1.splunk_saved_searches.lookup_template,
│   on ../../../modules/lookup_template/main.tf line 1, in resource "splunk_saved_searches" "lookup_template":
│    1: resource "splunk_saved_searches" "lookup_template" {
│
╵
2023-06-22T09:13:00.147-0400 [DEBUG] provider.stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = error reading from server: EOF"
```