### PR TITLE
Removed additional Status Code checks

### DIFF
--- a/splunk/resource_splunk_inputs_udp.go
+++ b/splunk/resource_splunk_inputs_udp.go
@@ -242,17 +242,7 @@ func inputsUDPDelete(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 	defer resp.Body.Close()
-
-	switch resp.StatusCode {
-	case 200, 201:
-		return nil
-
-	default:
-		errorResponse := &models.InputsUDPResponse{}
-		_ = json.NewDecoder(resp.Body).Decode(errorResponse)
-		err := errors.New(errorResponse.Messages[0].Text)
-		return err
-	}
+	return nil
 }
 
 // Helpers

--- a/splunk/resource_splunk_saved_searches.go
+++ b/splunk/resource_splunk_saved_searches.go
@@ -58,9 +58,9 @@ func savedSearches() *schema.Resource {
 					"4 - Warning",
 			},
 			"action_snow_event_param_description": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
 				Description: "	A brief description of the event.",
 			},
 			"action_snow_event_param_ci_identifier": {
@@ -1693,17 +1693,7 @@ func savedSearchesDelete(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 	defer resp.Body.Close()
-
-	switch resp.StatusCode {
-	case 200, 201:
-		return nil
-
-	default:
-		errorResponse := &models.InputsUDPResponse{}
-		_ = json.NewDecoder(resp.Body).Decode(errorResponse)
-		err := errors.New(errorResponse.Messages[0].Text)
-		return err
-	}
+	return nil
 }
 
 func getSavedSearchesConfig(d *schema.ResourceData) (savedSearchesObj *models.SavedSearchObject) {


### PR DESCRIPTION
Following up on the work done in
https://github.com/splunk/terraform-provider-splunk/pull/169. This removes the checking of the status code in a few places. This is duplicate work now and shouldn't be done in this place. It is now all handled in a central location.