### PR TITLE
Support Log Event Actions for saved_search resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.4.21
+* Fix: pagerduty integration key, custom details.
+
 ## 1.4.20
 * Support for defining pagerduty integration key, custom details.
 * Fix: Better error handling for non 20X error codes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.4.22
+* Fix: Encode name parameter of URI for Admin SAML Groups.
+
 ## 1.4.21
 * Fix: pagerduty integration key, custom details.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.20
+* Support for defining pagerduty integration key, custom details.
+* Fix: Better error handling for non 20X error codes.
+
 ## 1.4.19
 * Support for Pager Duty fields in saved_searches
 

--- a/client/models/saved_searches.go
+++ b/client/models/saved_searches.go
@@ -97,6 +97,12 @@ type SavedSearchObject struct {
 	ActionSummaryIndexMaxTime                    int     `json:"action.summary_index.maxtime,omitempty" url:"action.summary_index.maxtime,omitempty"`
 	ActionSummaryIndexTrackAlert                 bool    `json:"action.summary_index.track_alert" url:"action.summary_index.track_alert"`
 	ActionSummaryIndexTTL                        string  `json:"action.summary_index.ttl,omitempty" url:"action.summary_index.ttl,omitempty"`
+	ActionLogEvent                               string  `json:"action.logevent,omitempty" url:"action.logevent"`
+	ActionLogEventParamEvent                     string  `json:"action.logevent.param.event,omitempty" url:"action.logevent.param.event"`
+	ActionLogEventParamHost                      string  `json:"action.logevent.param.host,omitempty" url:"action.logevent.param.host"`
+	ActionLogEventParamIndex                     string  `json:"action.logevent.param.index,omitempty" url:"action.logevent.param.index"`
+	ActionLogEventParamSourceType                string  `json:"action.logevent.param.sourcetype,omitempty" url:"action.logevent.param.sourcetype"`
+	ActionLogEventParamSource                    string  `json:"action.logevent.param.source,omitempty" url:"action.logevent.param.source"`
 	ActionCreateXsoarIncident                    string  `json:"action.create_xsoar_incident,omitempty" url:"action.create_xsoar_incident"`
 	ActionCreateXsoarIncidentParamSendAllServers string  `json:"action.create_xsoar_incident.param.send_all_servers,omitempty" url:"action.create_xsoar_incident.param.send_all_servers"`
 	ActionCreateXsoarIncidentParamServerUrl      string  `json:"action.create_xsoar_incident.param.server_url,omitempty" url:"action.create_xsoar_incident.param.server_url"`

--- a/docs/resources/saved_searches.md
+++ b/docs/resources/saved_searches.md
@@ -106,7 +106,13 @@ This resource block supports the following arguments:
 * `action_summary_index_name` - (Optional) Specifies the name of the summary index where the results of the scheduled search are saved.Defaults to summary.
 * `action_summary_index_track_alert` - (Optional) Indicates whether the execution of this action signifies a trackable alert.
 * `action_summary_index_ttl` - (Optional) Valid values are: Integer[p] Specifies the minimum time-to-live in seconds of the search artifacts if this action is triggered. If p follows Integer, specifies the number of scheduled periods. Defaults to 86400 (24 hours).
-* `action_create_xsoar_incident` - (Optional) Enable XSOAR alerting (Should by 1 (Enabled) or 0 (Disabled))
+* `action_log_event` - (Optional) Enable XSOAR alerting (Should be 1 (Enabled) or 0 (Disabled))
+* `action_log_event_param_event` - (Optional) Specific event text for the logged event.
+* `action_log_event_param_host` - (Optional) Value for the host field of the logged event.
+* `action_log_event_param_index` - (Optional) Destination index where to store the logged event.
+* `action_log_event_param_sourcetype` - (Optional) Destination sourcetype where to store the logged event.
+* `action_log_event_param_source` - (Optional) Value for the source field of the logged event.
+* `action_create_xsoar_incident` - (Optional) Enable XSOAR alerting (Should be 1 (Enabled) or 0 (Disabled))
 * `action_create_xsoar_incident_param_send_all_servers` - (Optional) Enable XSOAR alerting sending to all servers (Should by 1 (Enabled) or 0 (Disabled)
 * `action_create_xsoar_incident_param_server_url` - (Optional) XSOAR Server instance URL (Should start with https:// || http://)
 * `action_create_xsoar_incident_param_incident_name` - (Optional) XSOAR incident name

--- a/splunk/resource_splunk_saved_searches.go
+++ b/splunk/resource_splunk_saved_searches.go
@@ -582,6 +582,36 @@ func savedSearches() *schema.Resource {
 				Description: "Valid values are: Integer[p] Specifies the minimum time-to-live in seconds of the search artifacts if this action is triggered. " +
 					"If p follows Integer, specifies the number of scheduled periods. Defaults to 86400 (24 hours).",
 			},
+			"action_log_event": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Enabled event logging.",
+			},
+			"action_log_event_param_event": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Event text for the logged event entry.",
+			},
+			"action_log_event_param_host": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Value of the host field for the logged event entry.",
+			},
+			"action_log_event_param_index": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Destination index for the logged event.",
+			},
+			"action_log_event_param_sourcetype": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Destination sourcetype for the logged event.",
+			},
+			"action_log_event_param_source": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Value of the source field for the logged event entry.",
+			},
 			"action_create_xsoar_incident": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -1427,6 +1457,24 @@ func savedSearchesRead(d *schema.ResourceData, meta interface{}) error {
 	if err = d.Set("action_summary_index_ttl", entry.Content.ActionSummaryIndexTTL); err != nil {
 		return err
 	}
+	if err = d.Set("action_log_event", entry.Content.ActionLogEvent); err != nil {
+		return err
+	}
+	if err = d.Set("action_log_event_param_event", entry.Content.ActionLogEventParamEvent); err != nil {
+		return err
+	}
+	if err = d.Set("action_log_event_param_host", entry.Content.ActionLogEventParamHost); err != nil {
+		return err
+	}
+	if err = d.Set("action_log_event_param_index", entry.Content.ActionLogEventParamIndex); err != nil {
+		return err
+	}
+	if err = d.Set("action_log_event_param_sourcetype", entry.Content.ActionLogEventParamSourceType); err != nil {
+		return err
+	}
+	if err = d.Set("action_log_event_param_source", entry.Content.ActionLogEventParamSource); err != nil {
+		return err
+	}
 	if err = d.Set("action_create_xsoar_incident", entry.Content.ActionCreateXsoarIncident); err != nil {
 		return err
 	}
@@ -1808,6 +1856,12 @@ func getSavedSearchesConfig(d *schema.ResourceData) (savedSearchesObj *models.Sa
 		ActionSummaryIndexName:                       d.Get("action_summary_index_name").(string),
 		ActionSummaryIndexTrackAlert:                 d.Get("action_summary_index_track_alert").(bool),
 		ActionSummaryIndexTTL:                        d.Get("action_summary_index_ttl").(string),
+		ActionLogEvent:                               d.Get("action_log_event").(string),
+		ActionLogEventParamEvent:                     d.Get("action_log_event_param_event").(string),
+		ActionLogEventParamHost:                      d.Get("action_log_event_param_host").(string),
+		ActionLogEventParamIndex:                     d.Get("action_log_event_param_index").(string),
+		ActionLogEventParamSourceType:                d.Get("action_log_event_param_sourcetype").(string),
+		ActionLogEventParamSource:                    d.Get("action_log_event_param_source").(string),
 		ActionCreateXsoarIncident:                    d.Get("action_create_xsoar_incident").(string),
 		ActionCreateXsoarIncidentParamSendAllServers: d.Get("action_create_xsoar_incident_param_send_all_servers").(string),
 		ActionCreateXsoarIncidentParamServerUrl:      d.Get("action_create_xsoar_incident_param_server_url").(string),

--- a/splunk/resource_splunk_saved_searches_test.go
+++ b/splunk/resource_splunk_saved_searches_test.go
@@ -97,6 +97,29 @@ resource "splunk_saved_searches" "test" {
     }
 }
 `
+const newSavedSearchesLogEvent = `
+resource "splunk_saved_searches" "test" {
+	name = "Test Log Event Alert"
+	actions = "logevent"
+	action_log_event = 1
+	action_log_event_param_event = "$result.js$"
+	action_log_event_param_host = "splunk"
+	action_log_event_param_index = "main"
+	action_log_event_param_sourcetype = "stash"
+	action_log_event_param_source = "alert:$name$"
+	alert_comparator    = "greater than"
+	alert_digest_mode   = true
+	alert_expires       = "30d"
+	alert_threshold     = "0"
+	alert_type          = "number of events"
+	cron_schedule       = "*/1 * * * *"
+	disabled            = false
+	is_scheduled        = true
+	is_visible          = true
+	realtime_schedule   = true
+	search              = "index=main level=error | eval js = json_object("source_ip", src_ip, "destination_ip", dest_ip)"
+}
+`
 
 const newSavedSearchesXsoar = `
 resource "splunk_saved_searches" "test" {
@@ -393,6 +416,30 @@ func TestAccSplunkSavedSearches(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "dispatch_index_latest", "-5m"),
 					resource.TestCheckResourceAttr(resourceName, "cron_schedule", "*/15 * * * *"),
 					resource.TestCheckResourceAttr(resourceName, "is_visible", "true"),
+				),
+			},
+			{
+				Config: newSavedSearchesLogEvent,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "Test Log Event Alert"),
+					resource.TestCheckResourceAttr(resourceName, "actions", "logevent"),
+					resource.TestCheckResourceAttr(resourceName, "action_log_event", "1"),
+					resource.TestCheckResourceAttr(resourceName, "action_log_event_param_event", "$result.js$"),
+					resource.TestCheckResourceAttr(resourceName, "action_log_event_param_host", "splunk"),
+					resource.TestCheckResourceAttr(resourceName, "action_log_event_param_index", "main"),
+					resource.TestCheckResourceAttr(resourceName, "action_log_event_param_sourcetype", "stash"),
+					resource.TestCheckResourceAttr(resourceName, "action_log_event_param_source", "alert:$name$"),
+					resource.TestCheckResourceAttr(resourceName, "alert_comparator", "greater than"),
+					resource.TestCheckResourceAttr(resourceName, "alert_digest_mode", "true"),
+					resource.TestCheckResourceAttr(resourceName, "alert_expires", "30d"),
+					resource.TestCheckResourceAttr(resourceName, "alert_threshold", "0"),
+					resource.TestCheckResourceAttr(resourceName, "alert_type", "number of events"),
+					resource.TestCheckResourceAttr(resourceName, "cron_schedule", "*/1 * * * *"),
+					resource.TestCheckResourceAttr(resourceName, "disabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "is_scheduled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "is_visible", "true"),
+					resource.TestCheckResourceAttr(resourceName, "realtime_schedule", "true"),
+					resource.TestCheckResourceAttr(resourceName, "search", "index=main level=error | eval js = json_object(\"source_ip\", src_ip, \"destination_ip\", dest_ip)"),
 				),
 			},
 			{


### PR DESCRIPTION
This commit will support log event actions for saved_search resources. I have validated this against a local splunk instance and confirmed it works as intended. 