### PR TITLE
ignore schedule priority when updating splunk_saved_search 

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -38,12 +38,13 @@ var defaultAuth = [2]string{"admin", "changeme"}
 
 // A Client is used to communicate with Splunkd endpoints
 type Client struct {
-	authToken  string
-	sessionKey string
-	auth       [2]string
-	host       string
-	httpClient *http.Client
-	userAgent  string
+	authToken              string
+	sessionKey             string
+	auth                   [2]string
+	host                   string
+	httpClient             *http.Client
+	userAgent              string
+	ignoreSchedulePriority bool
 }
 
 // NewRequest creates a new HTTP Request and set proper header
@@ -274,13 +275,14 @@ func NewDefaultSplunkdClient() (*Client, error) {
 }
 
 // NewSplunkdClient creates a Client with custom values passed in
-func NewSplunkdClient(sessionKey string, auth [2]string, host string, httpClient *http.Client) (*Client, error) {
+func NewSplunkdClient(sessionKey string, auth [2]string, host string, ignoreSchedulePriority bool, httpClient *http.Client) (*Client, error) {
 	c, err := NewDefaultSplunkdClient()
 	if err != nil {
 		return nil, err
 	}
 	c.auth = auth
 	c.host = host
+	c.ignoreSchedulePriority = ignoreSchedulePriority
 	c.sessionKey = sessionKey
 	if httpClient != nil {
 		c.httpClient = httpClient
@@ -289,13 +291,14 @@ func NewSplunkdClient(sessionKey string, auth [2]string, host string, httpClient
 }
 
 // NewSplunkdClient creates a Client with custom values passed in
-func NewSplunkdClientWithAuthToken(authToken string, auth [2]string, host string, httpClient *http.Client) (*Client, error) {
+func NewSplunkdClientWithAuthToken(authToken string, auth [2]string, host string, ignoreSchedulePriority bool, httpClient *http.Client) (*Client, error) {
 	c, err := NewDefaultSplunkdClient()
 	if err != nil {
 		return nil, err
 	}
 	c.auth = auth
 	c.host = host
+	c.ignoreSchedulePriority = ignoreSchedulePriority
 	c.authToken = authToken
 	if httpClient != nil {
 		c.httpClient = httpClient
@@ -325,4 +328,8 @@ func NewSplunkdHTTPClient(timeout time.Duration, skipValidateTLS bool) (*http.Cl
 
 	return client, nil
 
+}
+
+func (c *Client) GetIgnoreSchedulePriority() bool {
+	return c.ignoreSchedulePriority
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,7 @@ Below arguments for the provider can also be set as environment variables.
 If specified, auth token takes priority over username/password.
 * `insecure_skip_verify` or `SPLUNK_INSECURE_SKIP_VERIFY` - (Optional) Insecure skip verification flag (Defaults to `true`)
 * `timeout` or `SPLUNK_TIMEOUT` -  (Optional) Timeout when making calls to Splunk server. (Defaults to `60 seconds`)
+* `ignore_schedule_priority` or `SPLUNK_IGNORE_SCHEDULE_PRIORITY` -  (Optional) Ignore schedule_priority field in saved search. (Defaults to `false`)
 
 (NOTE: Auth token can only be used with certain type of Splunk deployments.
 Read more on authentication with tokens here: https://docs.splunk.com/Documentation/Splunk/latest/Security/Setupauthenticationwithtokens)

--- a/examples/aws/main.tf
+++ b/examples/aws/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     splunk = {
       source  = "splunk/splunk"
-      version = "1.4.4"
+      version = "1.4.25"
     }
   }
 }
@@ -20,10 +20,11 @@ provider "aws" {
 
 provider "splunk" {
   // Provide splunk instance credentials and details either via resource block or env variables
-  url                  = "localhost:8089"
-  username             = "admin"
-  password             = "changeme"
-  insecure_skip_verify = true
+  url                      = "localhost:8089"
+  username                 = "admin"
+  password                 = "changeme"
+  insecure_skip_verify     = true
+  ignore_schedule_priority = false
 }
 
 resource "splunk_indexes" "vpc-flow-logs-index" {

--- a/examples/splunk/basic/main.tf
+++ b/examples/splunk/basic/main.tf
@@ -17,11 +17,14 @@ provider "splunk" {
   username             = "admin"
   password             = "changeme"
   insecure_skip_verify = true
+  ignore_schedule_priority = false
+
   // Or use environment variables used:
   // SPLUNK_USERNAME
   // SPLUNK_PASSWORD
   // SPLUNK_URL
   // SPLUNK_INSECURE_SKIP_VERIFY (Defaults to true)
+  // SPLUNK_IGNORE_SCHEDULE_PRIORITY (Defaults to false)
 }
 
 resource "splunk_admin_saml_groups" "saml-group01" {

--- a/splunk/provider.go
+++ b/splunk/provider.go
@@ -65,6 +65,12 @@ func providerSchema() map[string]*schema.Schema {
 			DefaultFunc: schema.EnvDefaultFunc("SPLUNK_TIMEOUT", 60),
 			Description: "Timeout when making calls to Splunk server. Defaults to 60 seconds",
 		},
+		"ignore_schedule_priority": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			DefaultFunc: schema.EnvDefaultFunc("SPLUNK_IGNORE_SCHEDULE_PRIORITY", false),
+			Description: "Ignore schedule_priority field in saved search",
+		},
 	}
 }
 
@@ -115,6 +121,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		splunkdClient, err = client.NewSplunkdClientWithAuthToken(token.(string),
 			[2]string{d.Get("username").(string), d.Get("password").(string)},
 			d.Get("url").(string),
+			d.Get("insecure_skip_verify").(bool),
 			httpClient)
 		if err != nil {
 			return splunkdClient, err
@@ -123,6 +130,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		splunkdClient, err = client.NewSplunkdClient("",
 			[2]string{d.Get("username").(string), d.Get("password").(string)},
 			d.Get("url").(string),
+			d.Get("insecure_skip_verify").(bool),
 			httpClient)
 		if err != nil {
 			return splunkdClient, err

--- a/splunk/resource_splunk_saved_searches.go
+++ b/splunk/resource_splunk_saved_searches.go
@@ -1680,6 +1680,9 @@ func savedSearchesRead(d *schema.ResourceData, meta interface{}) error {
 func savedSearchesUpdate(d *schema.ResourceData, meta interface{}) error {
 	provider := meta.(*SplunkProvider)
 	savedSearchesConfig := getSavedSearchesConfig(d)
+	if provider.Client.GetIgnoreSchedulePriority() {
+		savedSearchesConfig.SchedulePriority = ""
+	}
 	aclObject := getACLConfig(d.Get("acl").([]interface{}))
 
 	// Update will create a new resource with private `user` permissions if resource had shared permissions set


### PR DESCRIPTION
## Description

As describe in #2, I get the following error when I am trying to update splunk_saved_search.

```
Error: Http Error: [400] 400 Bad Request {"messages":[{"type":"ERROR","text":"Argument \"schedule_priority\" is not supported by this handler."}]}
```

We are using Splunk Cloud and I am not admin of the Splunk instance. The token I use has been shared with me by a Splunk Admin and I do not have any way change anything about the Splunk TOKEN. So having this new flag `ignore_schedule_priority` was the only to go on

## Example usage

```hcl
provider "splunk" {
  url                  = "localhost:8089"
  username             = "admin"
  password             = "changeme"
  insecure_skip_verify = true
}
```