### PR TITLE
Add customfields to jira service desk params

### DIFF
--- a/client/models/saved_searches.go
+++ b/client/models/saved_searches.go
@@ -117,6 +117,7 @@ type SavedSearchObject struct {
 	ActionJiraServiceDeskParamJiraSummary        string  `json:"action.jira_service_desk.param.jira_summary,omitempty" url:"action.jira_service_desk.param.jira_summary"`
 	ActionJiraServiceDeskParamJiraPriority       string  `json:"action.jira_service_desk.param.jira_priority,omitempty" url:"action.jira_service_desk.param.jira_priority"`
 	ActionJiraServiceDeskParamJiraDescription    string  `json:"action.jira_service_desk.param.jira_description,omitempty" url:"action.jira_service_desk.param.jira_description"`
+	ActionJiraServiceDeskParamJiraCustomfields   string  `json:"action.jira_service_desk.param.jira_customfields,omitempty" url:"action.jira_service_desk.param.jira_customfields"`
 	ActionWebhookParamUrl                        string  `json:"action.webhook.param.url,omitempty" url:"action.webhook.param.url"`
 	AlertDigestMode                              bool    `json:"alert.digest_mode" url:"alert.digest_mode"`
 	AlertExpires                                 string  `json:"alert.expires,omitempty" url:"alert.expires,omitempty"`

--- a/docs/resources/saved_searches.md
+++ b/docs/resources/saved_searches.md
@@ -126,6 +126,7 @@ This resource block supports the following arguments:
 * `action_jira_service_desk_param_jira_summary` - (Optional) Jira issue title/summary
 * `action_jira_service_desk_param_jira_priority` - (Optional) Jira priority of issue
 * `action_jira_service_desk_param_jira_description` - (Optional) Jira issue description
+* `action_jira_service_desk_param_jira_customfields` - (Optional) Jira custom fields data (see https://ta-jira-service-desk-simple-addon.readthedocs.io/en/latest/userguide.html)
 * `action_webhook_param_url` - (Optional) URL to send the HTTP POST request to. Must be accessible from the Splunk server
 * `actions` - (Optional) A comma-separated list of actions to enable. For example: rss,email
 * `alert_comparator` - (Optional) One of the following strings: greater than, less than, equal to, rises by, drops by, rises by perc, drops by percUsed with alert_threshold to trigger alert actions.

--- a/splunk/resource_splunk_saved_searches.go
+++ b/splunk/resource_splunk_saved_searches.go
@@ -684,6 +684,11 @@ func savedSearches() *schema.Resource {
 				Optional:    true,
 				Description: "Enter the description of issue created",
 			},
+			"action_jira_service_desk_param_jira_customfields": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Enter custom fields data for the issue created",
+			},
 			"action_webhook_param_url": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -1487,6 +1492,9 @@ func savedSearchesRead(d *schema.ResourceData, meta interface{}) error {
 	if err = d.Set("action_jira_service_desk_param_jira_description", entry.Content.ActionJiraServiceDeskParamJiraDescription); err != nil {
 		return err
 	}
+	if err = d.Set("action_jira_service_desk_param_jira_customfields", entry.Content.ActionJiraServiceDeskParamJiraCustomfields); err != nil {
+		return err
+	}
 	if err = d.Set("action_webhook_param_url", entry.Content.ActionWebhookParamUrl); err != nil {
 		return err
 	}
@@ -1828,6 +1836,7 @@ func getSavedSearchesConfig(d *schema.ResourceData) (savedSearchesObj *models.Sa
 		ActionJiraServiceDeskParamJiraSummary:        d.Get("action_jira_service_desk_param_jira_summary").(string),
 		ActionJiraServiceDeskParamJiraPriority:       d.Get("action_jira_service_desk_param_jira_priority").(string),
 		ActionJiraServiceDeskParamJiraDescription:    d.Get("action_jira_service_desk_param_jira_description").(string),
+		ActionJiraServiceDeskParamJiraCustomfields:   d.Get("action_jira_service_desk_param_jira_customfields").(string),
 		ActionWebhookParamUrl:                        d.Get("action_webhook_param_url").(string),
 		AlertComparator:                              d.Get("alert_comparator").(string),
 		AlertCondition:                               d.Get("alert_condition").(string),

--- a/splunk/resource_splunk_saved_searches_test.go
+++ b/splunk/resource_splunk_saved_searches_test.go
@@ -207,7 +207,7 @@ resource "splunk_saved_searches" "test" {
 	action_jira_service_desk_param_jira_summary = "error message"
 	action_jira_service_desk_param_jira_priority = "Normal"
 	action_jira_service_desk_param_jira_description = "test ticket creation"
-	action_jira_service_desk_param_jira_customfields = "customfield_10058":{"value":"custom_field_value_1"},"customfield_10046":{"value":"custom_field_value_2"}
+	action_jira_service_desk_param_jira_customfields = "\"customfield_10058\":{\"value\":\"custom_field_value_1\"},\"customfield_10046\":{\"value\":\"custom_field_value_2\"}"
 	alert_comparator    = "greater than"
 	alert_digest_mode   = true
 	alert_expires       = "30d"

--- a/splunk/resource_splunk_saved_searches_test.go
+++ b/splunk/resource_splunk_saved_searches_test.go
@@ -467,7 +467,7 @@ func TestAccSplunkSavedSearches(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "action_jira_service_desk_param_jira_summary", "error message"),
 					resource.TestCheckResourceAttr(resourceName, "action_jira_service_desk_param_jira_priority", "Normal"),
 					resource.TestCheckResourceAttr(resourceName, "action_jira_service_desk_param_jira_description", "test ticket creation"),
-					resource.TestCheckResourceAttr(resourceName, "action_jira_service_desk_param_jira_description", "\"customfield_10058\":{\"value\":\"custom_field_value_1\"},\"customfield_10046\":{\"value\":\"custom_field_value_2\"}"),
+					resource.TestCheckResourceAttr(resourceName, "action_jira_service_desk_param_jira_customfields", "\"customfield_10058\":{\"value\":\"custom_field_value_1\"},\"customfield_10046\":{\"value\":\"custom_field_value_2\"}"),
 					resource.TestCheckResourceAttr(resourceName, "alert_comparator", "greater than"),
 					resource.TestCheckResourceAttr(resourceName, "alert_digest_mode", "true"),
 					resource.TestCheckResourceAttr(resourceName, "alert_expires", "30d"),

--- a/splunk/resource_splunk_saved_searches_test.go
+++ b/splunk/resource_splunk_saved_searches_test.go
@@ -207,6 +207,7 @@ resource "splunk_saved_searches" "test" {
 	action_jira_service_desk_param_jira_summary = "error message"
 	action_jira_service_desk_param_jira_priority = "Normal"
 	action_jira_service_desk_param_jira_description = "test ticket creation"
+	action_jira_service_desk_param_jira_customfields = "customfield_10058":{"value":"custom_field_value_1"},"customfield_10046":{"value":"custom_field_value_2"}
 	alert_comparator    = "greater than"
 	alert_digest_mode   = true
 	alert_expires       = "30d"
@@ -466,6 +467,7 @@ func TestAccSplunkSavedSearches(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "action_jira_service_desk_param_jira_summary", "error message"),
 					resource.TestCheckResourceAttr(resourceName, "action_jira_service_desk_param_jira_priority", "Normal"),
 					resource.TestCheckResourceAttr(resourceName, "action_jira_service_desk_param_jira_description", "test ticket creation"),
+					resource.TestCheckResourceAttr(resourceName, "action_jira_service_desk_param_jira_description", "\"customfield_10058\":{\"value\":\"custom_field_value_1\"},\"customfield_10046\":{\"value\":\"custom_field_value_2\"}"),
 					resource.TestCheckResourceAttr(resourceName, "alert_comparator", "greater than"),
 					resource.TestCheckResourceAttr(resourceName, "alert_digest_mode", "true"),
 					resource.TestCheckResourceAttr(resourceName, "alert_expires", "30d"),


### PR DESCRIPTION
In some Jira configurations, it is impossible to create issues without providing values for certain custom fields.

Adding support for customfields data improves usability of the Jira Service Desk addon in those environments.

I've tested this change successfully in my environment.