### PR TITLE
Fix wrong mapping from string to int of returned input script config

### DIFF
--- a/client/models/inputs_script.go
+++ b/client/models/inputs_script.go
@@ -7,9 +7,9 @@ type InputsScriptResponse struct {
 }
 
 type InputsScriptEntry struct {
-	Name    string             `json:"name"`
-	ACL     ACLObject          `json:"acl"`
-	Content InputsScriptObject `json:"content"`
+	Name    string                     `json:"name"`
+	ACL     ACLObject                  `json:"acl"`
+	Content InputsScriptObjectResponse `json:"content"`
 }
 
 type InputsScriptObject struct {
@@ -21,4 +21,15 @@ type InputsScriptObject struct {
 	PassAuth     string `json:"passAuth,omitempty" url:"passAuth,omitempty"`
 	Disabled     bool   `json:"disabled,omitempty" url:"disabled"`
 	Interval     int    `json:"interval,omitempty" url:"interval,omitempty"`
+}
+
+type InputsScriptObjectResponse struct {
+	Host         string      `json:"host,omitempty"`
+	Index        string      `json:"index,omitempty"`
+	Source       string      `json:"source,omitempty"`
+	SourceType   string      `json:"sourcetype,omitempty"`
+	RenameSource string      `json:"rename-source,omitempty"`
+	PassAuth     string      `json:"passAuth,omitempty"`
+	Disabled     bool        `json:"disabled,omitempty"`
+	Interval     interface{} `json:"interval,omitempty"` // Can be int or string
 }

--- a/splunk/resource_splunk_inputs_script.go
+++ b/splunk/resource_splunk_inputs_script.go
@@ -4,10 +4,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/splunk/terraform-provider-splunk/client/models"
 	"net/http"
 	"net/url"
 	"regexp"
+
+	"github.com/splunk/terraform-provider-splunk/client/models"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -68,7 +69,7 @@ func inputsScript() *schema.Resource {
 				Type:         schema.TypeInt,
 				Required:     true,
 				ValidateFunc: validation.IntAtLeast(60),
-				Description:  "Specify an integer or cron schedule. This parameter specifies how often to execute the specified script, in seconds or a valid cron schedule. If you specify a cron schedule, the script is not executed on start-up.",
+				Description:  "Specify an integer. This parameter specifies how often to execute the specified script, in seconds. Cron schedule is not supported",
 			},
 			"acl": aclSchema(),
 		},
@@ -138,6 +139,7 @@ func inputsScriptRead(d *schema.ResourceData, meta interface{}) error {
 	defer resp.Body.Close()
 
 	entry, err = getScriptedInputsConfigByName(name, resp)
+
 	if err != nil {
 		return err
 	}
@@ -170,7 +172,12 @@ func inputsScriptRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	if err = d.Set("interval", entry.Content.Interval); err != nil {
+	interval, ok := entry.Content.Interval.(float64)
+	if !ok {
+		fmt.Print(ok)
+		return err
+	}
+	if err = d.Set("interval", int(interval)); err != nil {
 		return err
 	}
 

--- a/splunk/resource_splunk_inputs_script_test.go
+++ b/splunk/resource_splunk_inputs_script_test.go
@@ -2,12 +2,13 @@ package splunk
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 const inputsScriptConfig = `


### PR DESCRIPTION
Fix input script resource to always map interval to integer. Integer is what we expect on the terraform input side, but inputs script can be configured with int or cron. When we read all input scripts from the API mapping to expected struct failed