### PR TITLE
Update stanza validation in resource_splunk_configs_conf.go 

### DIFF
--- a/splunk/resource_splunk_configs_conf.go
+++ b/splunk/resource_splunk_configs_conf.go
@@ -32,7 +32,7 @@ func configsConf() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9_\-.]+/[a-zA-Z0-9_\-.]+`), "A '/' separated string consisting of {conf_file_name}/{stanza_name} ex. props/custom_stanza"),
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9_\-.]+/[a-zA-Z0-9_\-.:/]+`), "A '/' separated string consisting of {conf_file_name}/{stanza_name} ex. props/custom_stanza"),
 				Description:  `A '/' separated string consisting of {conf_file_name}/{stanza_name} ex. props/custom_stanza`,
 			},
 			"acl": aclSchema(),

--- a/splunk/resource_splunk_configs_conf_test.go
+++ b/splunk/resource_splunk_configs_conf_test.go
@@ -10,7 +10,7 @@ import (
 
 const newConfigsConf = `
 resource "splunk_configs_conf" "tftest-stanza" {
-	name = "tf_test/tftest_stanza"
+	name = "tf_test/sqs://tftest_stanza"
 	variables = {
         "disabled": "false"
 		"key": "value"
@@ -20,7 +20,7 @@ resource "splunk_configs_conf" "tftest-stanza" {
 
 const updateConfigsConf = `
 resource "splunk_configs_conf" "tftest-stanza" {
-	name = "tf_test/tftest_stanza"
+	name = "tf_test/sqs://tftest_stanza"
 	variables = {
         "disabled": "false"
 		"key": "new-value"

--- a/splunk/resource_splunk_configs_conf_test.go
+++ b/splunk/resource_splunk_configs_conf_test.go
@@ -10,7 +10,7 @@ import (
 
 const newConfigsConf = `
 resource "splunk_configs_conf" "tftest-stanza" {
-	name = "tf_test/sqs://tftest_stanza"
+	name = "tf_test/tftest_stanza"
 	variables = {
         "disabled": "false"
 		"key": "value"
@@ -20,7 +20,7 @@ resource "splunk_configs_conf" "tftest-stanza" {
 
 const updateConfigsConf = `
 resource "splunk_configs_conf" "tftest-stanza" {
-	name = "tf_test/sqs://tftest_stanza"
+	name = "tf_test/tftest_stanza"
 	variables = {
         "disabled": "false"
 		"key": "new-value"
@@ -59,6 +59,59 @@ func TestAccCreateSplunkConfigsConf(t *testing.T) {
 		},
 	})
 }
+
+const newConfigsConfSpecialChars = `
+resource "splunk_configs_conf" "tftest-stanza-special-chars" {
+	name = "tf_test/sqs://tftest_stanza_special_chars"
+	variables = {
+        "disabled": "false"
+		"key": "value"
+	}
+}
+`
+
+const updateConfigsConfSpecialChars = `
+resource "splunk_configs_conf" "tftest-stanza-special-chars" {
+	name = "tf_test/sqs://tftest_stanza_special_chars"
+	variables = {
+        "disabled": "false"
+		"key": "new-value"
+	}
+}
+`
+
+func TestAccCreateSplunkConfigsConf(t *testing.T) {
+	resourceName := "splunk_configs_conf.tftest-stanza-special-chars"
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccSplunkConfigsConfDestroyResources,
+		Steps: []resource.TestStep{
+			{
+				Config: newConfigsConfSpecialChars,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "variables.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "variables.key", "value"),
+				),
+			},
+			{
+				Config: updateConfigsConfSpecialChars,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "variables.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "variables.key", "new-value"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 
 func testAccSplunkConfigsConfDestroyResources(s *terraform.State) error {
 	client, err := newTestClient()

--- a/splunk/resource_splunk_configs_conf_test.go
+++ b/splunk/resource_splunk_configs_conf_test.go
@@ -80,7 +80,7 @@ resource "splunk_configs_conf" "tftest-stanza-special-chars" {
 }
 `
 
-func TestAccCreateSplunkConfigsConf(t *testing.T) {
+func TestAccCreateSplunkConfigsConfSpecialChars(t *testing.T) {
 	resourceName := "splunk_configs_conf.tftest-stanza-special-chars"
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {


### PR DESCRIPTION
Update stanza validation regex to support ':' and '/' characters in the stanza.

These characters are required for creation of inputs using the Splunk Addon for AWS, which creates inputs with a name like: aws_sqs_based_s3://s3-bucket-name. 

Link to Splunk Addon for AWS: https://splunk.github.io/splunk-add-on-for-amazon-web-services/