### PR TITLE
Fix tests broken by url parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.4.31
+* Fix: URL parsing of Splunk client path
+
 ## 1.4.30
 * Suppress defaults when planning changes to Jira service desk params
 

--- a/splunk/provider.go
+++ b/splunk/provider.go
@@ -2,6 +2,7 @@ package splunk
 
 import (
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/splunk/terraform-provider-splunk/client"
@@ -115,7 +116,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	}
 	// Ensure scheme to parse host and path
 	providerUrl := d.Get("url").(string)
-	if !hasHTTPScheme(providerUrl) {
+	if !hasScheme(providerUrl) {
 		providerUrl = "http://" + providerUrl // add http scheme so url.Parse works
 	}
 	u, err := url.Parse(providerUrl)
@@ -151,11 +152,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	return provider, nil
 }
 
-// hasHTTPScheme checks if a string has an "http" or "https" scheme using url.Parse.
-func hasHTTPScheme(s string) bool {
-	u, err := url.Parse(s)
-	if err != nil {
-		return false // Invalid URL
-	}
-	return u.Scheme == "http" || u.Scheme == "https"
+// hasScheme checks if a string has an "://"
+func hasScheme(s string) bool {
+	return strings.Contains(s, "://") // require URL scheme
 }

--- a/splunk/provider.go
+++ b/splunk/provider.go
@@ -2,7 +2,6 @@ package splunk
 
 import (
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/splunk/terraform-provider-splunk/client"
@@ -153,6 +152,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 }
 
 // hasScheme checks if a string has an "://"
-func hasScheme(s string) bool {
-	return strings.Contains(s, "://") // require URL scheme
+func hasScheme(providerUrl string) bool {
+	parsed, err := url.Parse(providerUrl)
+	return err == nil && parsed.Scheme != "" && parsed.Host != ""
 }

--- a/splunk/provider.go
+++ b/splunk/provider.go
@@ -151,7 +151,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	return provider, nil
 }
 
-// hasScheme checks if a string has an "://"
+// hasScheme checks if a URL has scheme and host
 func hasScheme(providerUrl string) bool {
 	parsed, err := url.Parse(providerUrl)
 	return err == nil && parsed.Scheme != "" && parsed.Host != ""

--- a/splunk/provider_test.go
+++ b/splunk/provider_test.go
@@ -1,6 +1,7 @@
 package splunk
 
 import (
+	"net/url"
 	"os"
 	"testing"
 	"time"
@@ -31,11 +32,22 @@ func newTestClient() (*client.Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Parse splunk url host
+	SPLUNK_URL := (os.Getenv("SPLUNK_URL"))
+	if !hasHTTPScheme(SPLUNK_URL) {
+		SPLUNK_URL = "http://" + SPLUNK_URL // add http scheme so url.Parse works
+	}
+	u, err := url.Parse(SPLUNK_URL)
+	if err != nil {
+		return nil, err
+	}
+	host := u.Host
+
 	return client.NewSplunkdClient(
 		"",
 		[2]string{os.Getenv("SPLUNK_USERNAME"),
 			os.Getenv("SPLUNK_PASSWORD")},
-		os.Getenv("SPLUNK_URL"),
+		host,
 		"",
 		http)
 }

--- a/splunk/provider_test.go
+++ b/splunk/provider_test.go
@@ -34,7 +34,7 @@ func newTestClient() (*client.Client, error) {
 	}
 	// Parse splunk url host
 	SPLUNK_URL := (os.Getenv("SPLUNK_URL"))
-	if !hasHTTPScheme(SPLUNK_URL) {
+	if !hasScheme(SPLUNK_URL) {
 		SPLUNK_URL = "http://" + SPLUNK_URL // add http scheme so url.Parse works
 	}
 	u, err := url.Parse(SPLUNK_URL)


### PR DESCRIPTION
url.Parse function does not always parse Host and Path correctly without http scheme. 
Temporarily add http scheme to SPLUNK_URL provider configuration parameter before parsing host and path (keeps default "https://" scheme in case of no scheme specified)

Fix provider_test broken by https://github.com/splunk/terraform-provider-splunk/pull/148 

Bump version and add CHANGELOG entry