### PR TITLE
Fix generic_acl app ACL updates on Splunk Cloud

### DIFF
--- a/client/acl.go
+++ b/client/acl.go
@@ -75,6 +75,36 @@ func (client *Client) ResourcesAndNameForPath(path string) (resources []string, 
 }
 
 func (client *Client) UpdateAcl(owner, app, name string, acl *models.ACLObject, resources ...string) error {
+	if !strings.EqualFold(strings.TrimSpace(client.ACLGetMode), ACLGetModeCloud) {
+		values, err := query.Values(&acl)
+		if err != nil {
+			return err
+		}
+		// remove app from url values during POST
+		values.Del("app")
+		values.Del("perms[read]")
+		values.Del("perms[write]")
+		// Flatten []string
+		values.Set("perms.read", strings.Join(acl.Perms.Read, ","))
+		values.Set("perms.write", strings.Join(acl.Perms.Write, ","))
+		// Adding resources
+		resourcePath := []string{"servicesNS", owner, app}
+		resourcePath = append(resourcePath, resources...)
+		resourcePath = append(resourcePath, name, "acl")
+		endpoint := client.BuildSplunkURL(nil, resourcePath...)
+		resp, err := client.Post(endpoint, values)
+		if err != nil {
+			return fmt.Errorf("POST failed for endpoint %s: %s", endpoint.Path, err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+			return fmt.Errorf("POST failed for endpoint %s: %s", endpoint.Path, resp.Status)
+		}
+
+		return nil
+	}
+
 	values := url.Values{}
 	if owner != "" {
 		values.Set("owner", owner)

--- a/client/acl.go
+++ b/client/acl.go
@@ -93,20 +93,23 @@ func (client *Client) UpdateAcl(owner, app, name string, acl *models.ACLObject, 
 	resourcePath = append(resourcePath, name, "acl")
 	endpoint := client.BuildSplunkURL(nil, resourcePath...)
 	resp, err := client.Post(endpoint, values)
-	requestBody, _ := httputil.DumpRequest(resp.Request, false)
 	if err != nil {
-		return fmt.Errorf("GET failed for endpoint %s: %s", endpoint.Path, err)
+		return fmt.Errorf("POST failed for endpoint %s: %s", endpoint.Path, err)
 	}
-
 	defer resp.Body.Close()
 
-	respBody, error := httputil.DumpResponse(resp, true)
-	if error != nil {
-		log.Printf("[ERROR] Error occured during acl creation %s", error)
+	requestBody, _ := httputil.DumpRequest(resp.Request, false)
+	respBody, dumpErr := httputil.DumpResponse(resp, true)
+	if dumpErr != nil {
+		log.Printf("[ERROR] Error occured during acl update %s", dumpErr)
 	}
 
 	log.Printf("[DEBUG] Request object coming acl is: %s and body: %s", string(requestBody), string(values.Encode()))
-	log.Printf("[DEBUG] Response object returned from acl creation: %s", string(respBody))
+	log.Printf("[DEBUG] Response object returned from acl update: %s", string(respBody))
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return fmt.Errorf("POST failed for endpoint %s: %s", endpoint.Path, resp.Status)
+	}
 
 	return nil
 }

--- a/client/acl.go
+++ b/client/acl.go
@@ -100,7 +100,7 @@ func (client *Client) UpdateAcl(owner, app, name string, acl *models.ACLObject, 
 		Host:   client.host,
 		Path:   buildPath,
 	}
-	resp, err := client.Post(endpoint, values)
+	resp, err := client.Post(endpoint, []byte(values.Encode()))
 	if err != nil {
 		return fmt.Errorf("POST failed for endpoint %s: %s", endpoint.Path, err)
 	}

--- a/client/acl.go
+++ b/client/acl.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/google/go-querystring/query"
 	"github.com/splunk/terraform-provider-splunk/client/models"
 )
 

--- a/client/acl.go
+++ b/client/acl.go
@@ -75,67 +75,60 @@ func (client *Client) ResourcesAndNameForPath(path string) (resources []string, 
 }
 
 func (client *Client) UpdateAcl(owner, app, name string, acl *models.ACLObject, resources ...string) error {
-	if !strings.EqualFold(strings.TrimSpace(client.ACLGetMode), ACLGetModeCloud) {
-		values, err := query.Values(&acl)
-		if err != nil {
-			return err
-		}
-		// remove app from url values during POST
-		values.Del("app")
-		values.Del("perms[read]")
-		values.Del("perms[write]")
-		// Flatten []string
-		values.Set("perms.read", strings.Join(acl.Perms.Read, ","))
-		values.Set("perms.write", strings.Join(acl.Perms.Write, ","))
-		// Adding resources
-		resourcePath := []string{"servicesNS", owner, app}
-		resourcePath = append(resourcePath, resources...)
-		resourcePath = append(resourcePath, name, "acl")
-		endpoint := client.BuildSplunkURL(nil, resourcePath...)
-		resp, err := client.Post(endpoint, values)
-		if err != nil {
-			return fmt.Errorf("POST failed for endpoint %s: %s", endpoint.Path, err)
-		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-			return fmt.Errorf("POST failed for endpoint %s: %s", endpoint.Path, resp.Status)
-		}
-
-		return nil
-	}
-
-	values := url.Values{}
-	if owner != "" {
-		values.Set("owner", owner)
-	}
-	if acl.Sharing != "" {
-		values.Set("sharing", acl.Sharing)
-	}
-	values.Set("perms.read", strings.Join(acl.Perms.Read, ","))
-	values.Set("perms.write", strings.Join(acl.Perms.Write, ","))
-	// Adding resources
 	resourcePath := []string{"servicesNS", owner, app}
 	resourcePath = append(resourcePath, resources...)
 	resourcePath = append(resourcePath, name, "acl")
-	buildPath := client.path
-	for _, pathPart := range resourcePath {
-		pathPart = strings.ReplaceAll(pathPart, " ", "+")
-		buildPath = path.Join(buildPath, pathPart)
-	}
-	endpoint := url.URL{
-		Scheme: getEnv(envVarHTTPScheme, defaultScheme),
-		Host:   client.host,
-		Path:   buildPath,
-	}
+	isCloud := strings.EqualFold(strings.TrimSpace(client.ACLGetMode), ACLGetModeCloud)
 
-	req, err := client.NewRequest(http.MethodPost, endpoint.String(), strings.NewReader(values.Encode()))
-	if err != nil {
-		return fmt.Errorf("POST failed for endpoint %s: %s", endpoint.Path, err)
-	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	var (
+		resp     *http.Response
+		err      error
+		endpoint url.URL
+	)
 
-	resp, err := client.Do(req)
+	if isCloud {
+		values := url.Values{}
+		if owner != "" {
+			values.Set("owner", owner)
+		}
+		if acl.Sharing != "" {
+			values.Set("sharing", acl.Sharing)
+		}
+		values.Set("perms.read", strings.Join(acl.Perms.Read, ","))
+		values.Set("perms.write", strings.Join(acl.Perms.Write, ","))
+
+		buildPath := client.path
+		for _, pathPart := range resourcePath {
+			pathPart = strings.ReplaceAll(pathPart, " ", "+")
+			buildPath = path.Join(buildPath, pathPart)
+		}
+		endpoint = url.URL{
+			Scheme: getEnv(envVarHTTPScheme, defaultScheme),
+			Host:   client.host,
+			Path:   buildPath,
+		}
+
+		req, reqErr := client.NewRequest(http.MethodPost, endpoint.String(), strings.NewReader(values.Encode()))
+		if reqErr != nil {
+			return fmt.Errorf("POST failed for endpoint %s: %s", endpoint.Path, reqErr)
+		}
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		resp, err = client.Do(req)
+	} else {
+		values, valuesErr := query.Values(&acl)
+		if valuesErr != nil {
+			return valuesErr
+		}
+		values.Del("app")
+		values.Del("perms[read]")
+		values.Del("perms[write]")
+		values.Set("perms.read", strings.Join(acl.Perms.Read, ","))
+		values.Set("perms.write", strings.Join(acl.Perms.Write, ","))
+
+		endpoint = client.BuildSplunkURL(nil, resourcePath...)
+		resp, err = client.Post(endpoint, values)
+	}
 	if err != nil {
 		return fmt.Errorf("POST failed for endpoint %s: %s", endpoint.Path, err)
 	}

--- a/client/acl.go
+++ b/client/acl.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/google/go-querystring/query"
 	"github.com/splunk/terraform-provider-splunk/client/models"
 )
 
@@ -76,15 +75,13 @@ func (client *Client) ResourcesAndNameForPath(path string) (resources []string, 
 }
 
 func (client *Client) UpdateAcl(owner, app, name string, acl *models.ACLObject, resources ...string) error {
-	values, err := query.Values(&acl)
-	if err != nil {
-		return err
+	values := url.Values{}
+	if owner != "" {
+		values.Set("owner", owner)
 	}
-	// remove app from url values during POST
-	values.Del("app")
-	values.Del("perms[read]")
-	values.Del("perms[write]")
-	// Flatten []string
+	if acl.Sharing != "" {
+		values.Set("sharing", acl.Sharing)
+	}
 	values.Set("perms.read", strings.Join(acl.Perms.Read, ","))
 	values.Set("perms.write", strings.Join(acl.Perms.Write, ","))
 	// Adding resources

--- a/client/acl.go
+++ b/client/acl.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"path"
 	"strings"
 
 	"github.com/google/go-querystring/query"
@@ -89,17 +90,16 @@ func (client *Client) UpdateAcl(owner, app, name string, acl *models.ACLObject, 
 	resourcePath := []string{"servicesNS", owner, app}
 	resourcePath = append(resourcePath, resources...)
 	resourcePath = append(resourcePath, name, "acl")
-	var q url.Values
-	if strings.EqualFold(strings.TrimSpace(client.ACLGetMode), ACLGetModeCloud) {
-		q = url.Values{}
-		if owner != "" {
-			q.Set("owner", owner)
-		}
-		if acl.Sharing != "" {
-			q.Set("sharing", acl.Sharing)
-		}
+	buildPath := client.path
+	for _, pathPart := range resourcePath {
+		pathPart = strings.ReplaceAll(pathPart, " ", "+")
+		buildPath = path.Join(buildPath, pathPart)
 	}
-	endpoint := client.BuildSplunkURL(q, resourcePath...)
+	endpoint := url.URL{
+		Scheme: getEnv(envVarHTTPScheme, defaultScheme),
+		Host:   client.host,
+		Path:   buildPath,
+	}
 	resp, err := client.Post(endpoint, values)
 	if err != nil {
 		return fmt.Errorf("POST failed for endpoint %s: %s", endpoint.Path, err)

--- a/client/acl.go
+++ b/client/acl.go
@@ -98,6 +98,9 @@ func (client *Client) UpdateAcl(owner, app, name string, acl *models.ACLObject, 
 		values.Set("perms.read", readPerms)
 		values.Set("perms.write", writePerms)
 
+		// Splunk Cloud app ACL updates require a raw form-encoded POST body here; the
+		// generic client.Post/object-encoding path can return 200 OK without persisting
+		// the ACL change.
 		req, reqErr := client.NewRequest(http.MethodPost, endpoint.String(), strings.NewReader(values.Encode()))
 		if reqErr != nil {
 			return fmt.Errorf("POST failed for endpoint %s: %s", endpoint.Path, reqErr)

--- a/client/acl.go
+++ b/client/acl.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 
 	"github.com/google/go-querystring/query"
@@ -78,14 +77,14 @@ func (client *Client) UpdateAcl(owner, app, name string, acl *models.ACLObject, 
 	resourcePath := []string{"servicesNS", owner, app}
 	resourcePath = append(resourcePath, resources...)
 	resourcePath = append(resourcePath, name, "acl")
+	endpoint := client.BuildSplunkURL(nil, resourcePath...)
 	isCloud := strings.EqualFold(strings.TrimSpace(client.ACLGetMode), ACLGetModeCloud)
 	readPerms := strings.Join(acl.Perms.Read, ",")
 	writePerms := strings.Join(acl.Perms.Write, ",")
 
 	var (
-		resp     *http.Response
-		err      error
-		endpoint url.URL
+		resp *http.Response
+		err  error
 	)
 
 	if isCloud {
@@ -98,17 +97,6 @@ func (client *Client) UpdateAcl(owner, app, name string, acl *models.ACLObject, 
 		}
 		values.Set("perms.read", readPerms)
 		values.Set("perms.write", writePerms)
-
-		buildPath := client.path
-		for _, pathPart := range resourcePath {
-			pathPart = strings.ReplaceAll(pathPart, " ", "+")
-			buildPath = path.Join(buildPath, pathPart)
-		}
-		endpoint = url.URL{
-			Scheme: getEnv(envVarHTTPScheme, defaultScheme),
-			Host:   client.host,
-			Path:   buildPath,
-		}
 
 		req, reqErr := client.NewRequest(http.MethodPost, endpoint.String(), strings.NewReader(values.Encode()))
 		if reqErr != nil {
@@ -127,8 +115,6 @@ func (client *Client) UpdateAcl(owner, app, name string, acl *models.ACLObject, 
 		values.Del("perms[write]")
 		values.Set("perms.read", readPerms)
 		values.Set("perms.write", writePerms)
-
-		endpoint = client.BuildSplunkURL(nil, resourcePath...)
 		resp, err = client.Post(endpoint, values)
 	}
 	if err != nil {

--- a/client/acl.go
+++ b/client/acl.go
@@ -91,7 +91,17 @@ func (client *Client) UpdateAcl(owner, app, name string, acl *models.ACLObject, 
 	resourcePath := []string{"servicesNS", owner, app}
 	resourcePath = append(resourcePath, resources...)
 	resourcePath = append(resourcePath, name, "acl")
-	endpoint := client.BuildSplunkURL(nil, resourcePath...)
+	var q url.Values
+	if strings.EqualFold(strings.TrimSpace(client.ACLGetMode), ACLGetModeCloud) {
+		q = url.Values{}
+		if owner != "" {
+			q.Set("owner", owner)
+		}
+		if acl.Sharing != "" {
+			q.Set("sharing", acl.Sharing)
+		}
+	}
+	endpoint := client.BuildSplunkURL(q, resourcePath...)
 	resp, err := client.Post(endpoint, values)
 	if err != nil {
 		return fmt.Errorf("POST failed for endpoint %s: %s", endpoint.Path, err)

--- a/client/acl.go
+++ b/client/acl.go
@@ -3,9 +3,7 @@ package client
 import (
 	"fmt"
 	"io"
-	"log"
 	"net/http"
-	"net/http/httputil"
 	"net/url"
 	"path"
 	"strings"
@@ -112,15 +110,6 @@ func (client *Client) UpdateAcl(owner, app, name string, acl *models.ACLObject, 
 		return fmt.Errorf("POST failed for endpoint %s: %s", endpoint.Path, err)
 	}
 	defer resp.Body.Close()
-
-	requestBody, _ := httputil.DumpRequestOut(req, true)
-	respBody, dumpErr := httputil.DumpResponse(resp, true)
-	if dumpErr != nil {
-		log.Printf("[ERROR] Error occured during acl update %s", dumpErr)
-	}
-
-	log.Printf("[DEBUG] Request object coming acl is: %s and body: %s", string(requestBody), string(values.Encode()))
-	log.Printf("[DEBUG] Response object returned from acl update: %s", string(respBody))
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		return fmt.Errorf("POST failed for endpoint %s: %s", endpoint.Path, resp.Status)

--- a/client/acl.go
+++ b/client/acl.go
@@ -100,13 +100,20 @@ func (client *Client) UpdateAcl(owner, app, name string, acl *models.ACLObject, 
 		Host:   client.host,
 		Path:   buildPath,
 	}
-	resp, err := client.Post(endpoint, []byte(values.Encode()))
+
+	req, err := client.NewRequest(http.MethodPost, endpoint.String(), strings.NewReader(values.Encode()))
+	if err != nil {
+		return fmt.Errorf("POST failed for endpoint %s: %s", endpoint.Path, err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("POST failed for endpoint %s: %s", endpoint.Path, err)
 	}
 	defer resp.Body.Close()
 
-	requestBody, _ := httputil.DumpRequest(resp.Request, false)
+	requestBody, _ := httputil.DumpRequestOut(req, true)
 	respBody, dumpErr := httputil.DumpResponse(resp, true)
 	if dumpErr != nil {
 		log.Printf("[ERROR] Error occured during acl update %s", dumpErr)

--- a/client/acl.go
+++ b/client/acl.go
@@ -79,6 +79,8 @@ func (client *Client) UpdateAcl(owner, app, name string, acl *models.ACLObject, 
 	resourcePath = append(resourcePath, resources...)
 	resourcePath = append(resourcePath, name, "acl")
 	isCloud := strings.EqualFold(strings.TrimSpace(client.ACLGetMode), ACLGetModeCloud)
+	readPerms := strings.Join(acl.Perms.Read, ",")
+	writePerms := strings.Join(acl.Perms.Write, ",")
 
 	var (
 		resp     *http.Response
@@ -94,8 +96,8 @@ func (client *Client) UpdateAcl(owner, app, name string, acl *models.ACLObject, 
 		if acl.Sharing != "" {
 			values.Set("sharing", acl.Sharing)
 		}
-		values.Set("perms.read", strings.Join(acl.Perms.Read, ","))
-		values.Set("perms.write", strings.Join(acl.Perms.Write, ","))
+		values.Set("perms.read", readPerms)
+		values.Set("perms.write", writePerms)
 
 		buildPath := client.path
 		for _, pathPart := range resourcePath {
@@ -123,8 +125,8 @@ func (client *Client) UpdateAcl(owner, app, name string, acl *models.ACLObject, 
 		values.Del("app")
 		values.Del("perms[read]")
 		values.Del("perms[write]")
-		values.Set("perms.read", strings.Join(acl.Perms.Read, ","))
-		values.Set("perms.write", strings.Join(acl.Perms.Write, ","))
+		values.Set("perms.read", readPerms)
+		values.Set("perms.write", writePerms)
 
 		endpoint = client.BuildSplunkURL(nil, resourcePath...)
 		resp, err = client.Post(endpoint, values)


### PR DESCRIPTION
## Summary
This fixes `splunk_generic_acl` app ACL updates on Splunk Cloud.

## Root Cause
`UpdateAcl` was sending ACL updates through the provider's generic `Post`/`DoRequest` encoding path. Although the logged fields looked similar to a working `curl`, Splunk Cloud did not actually persist the ACL update from that request path.

We verified this by comparing against a manual request that did work immediately on the same endpoint with the same ACL fields:
- `owner`
- `sharing`
- `perms.read`
- `perms.write`

The failing provider path also caused confusing follow-up behavior:
- older versions surfaced stale or empty ACL values after apply
- `1.4.36` could misreport a POST failure as `GET failed`
- the underlying issue was the ACL update request construction, not the Terraform config

## Fix
Build the ACL update request manually in `client/acl.go` and send it as a raw `application/x-www-form-urlencoded` POST.

The fixed path now:
- builds the form body explicitly with only `owner`, `sharing`, `perms.read`, and `perms.write`
- bypasses the generic object encoder for ACL updates
- sends the request with an explicit form body and headers

## Validation
Validated against Splunk Cloud `10.2.2510.12` using `splunk_generic_acl` on an app endpoint like:
- `servicesNS/nobody/system/apps/local/<app>/acl`

Before this patch:
- POST returned `200 OK` but the ACL was not updated
- follow-up state showed stale or empty permissions

After this patch:
- the same apply path updates the ACL successfully
- the apply completes without the earlier ACL mismatch behavior
