### PR TITLE
Fix HEC useACK unmarshal error on Splunk Cloud 8.2+

### DIFF
--- a/client/models/http_event_collector.go
+++ b/client/models/http_event_collector.go
@@ -1,5 +1,45 @@
 package models
 
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// IntBool is a custom type that can unmarshal JSON values that may be
+// represented as integers ("0"/"1"), booleans ("true"/"false"), or their
+// unquoted equivalents. Splunk Cloud 8.2+ returns "true"/"false" for useACK
+// instead of "0"/"1" which breaks the standard json:",string" tag.
+type IntBool int
+
+func (ib *IntBool) UnmarshalJSON(data []byte) error {
+	// Remove surrounding quotes if present
+	s := strings.Trim(string(data), "\"")
+
+	// Try parsing as integer first
+	if i, err := strconv.Atoi(s); err == nil {
+		*ib = IntBool(i)
+		return nil
+	}
+
+	// Try parsing as boolean
+	if b, err := strconv.ParseBool(s); err == nil {
+		if b {
+			*ib = 1
+		} else {
+			*ib = 0
+		}
+		return nil
+	}
+
+	return fmt.Errorf("cannot unmarshal %s into IntBool", string(data))
+}
+
+func (ib IntBool) MarshalJSON() ([]byte, error) {
+	return json.Marshal(int(ib))
+}
+
 // HTTP Input Response Schema
 type HECResponse struct {
 	Entry    []HECEntry     `json:"entry"`
@@ -20,5 +60,5 @@ type HttpEventCollectorObject struct {
 	SourceType string        `json:"sourcetype,omitempty" url:"sourcetype,omitempty"`
 	Token      string        `json:"token,omitempty" url:"token,omitempty"`
 	Disabled   bool          `json:"disabled,omitempty" url:"disabled"`
-	UseACK     int           `json:"useACK,string,omitempty" url:"useACK"`
+	UseACK     IntBool       `json:"useACK" url:"useACK"`
 }

--- a/splunk/resource_splunk_inputs_http_event_collector.go
+++ b/splunk/resource_splunk_inputs_http_event_collector.go
@@ -178,7 +178,7 @@ func httpEventCollectorInputRead(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
-	if err = d.Set("use_ack", entry.Content.UseACK); err != nil {
+	if err = d.Set("use_ack", int(entry.Content.UseACK)); err != nil {
 		return err
 	}
 
@@ -238,7 +238,7 @@ func getHttpEventCollectorConfig(d *schema.ResourceData) (httpInputConfigObject 
 	httpInputConfigObject.Indexes = d.Get("indexes").([]interface{})
 	httpInputConfigObject.Source = d.Get("source").(string)
 	httpInputConfigObject.SourceType = d.Get("sourcetype").(string)
-	httpInputConfigObject.UseACK = d.Get("use_ack").(int)
+	httpInputConfigObject.UseACK = models.IntBool(d.Get("use_ack").(int))
 	httpInputConfigObject.Disabled = d.Get("disabled").(bool)
 	return httpInputConfigObject
 }


### PR DESCRIPTION
## Description

Fixes #130

On Splunk Cloud 8.2+ (Victoria Experience), the HTTP Event Collector API returns `"true"`/`"false"` as string values for the `useACK` field, instead of the numeric `"0"`/`"1"` returned by earlier versions. This causes the JSON decoder to fail with:

```
json: invalid use of ,string struct tag, trying to unmarshal "true" into int
```

## Changes

- Introduced a custom `IntBool` type in `client/models/http_event_collector.go` that implements `json.Unmarshaler`
- The custom type handles both numeric strings (`"0"`/`"1"`) and boolean strings (`"true"`/`"false"`)
- Updated `HttpEventCollectorObject.UseACK` field from `int` to `IntBool`
- Updated the resource code to cast `IntBool` to `int` when interacting with the Terraform schema

## Impact

This is a backward-compatible fix. The `use_ack` attribute in the Terraform schema remains `TypeInt` (0 or 1). The custom type transparently handles both response formats from different Splunk versions.