### PR TITLE
Add namespaced REST import support

### DIFF
--- a/client/acl.go
+++ b/client/acl.go
@@ -23,10 +23,6 @@ func (client *Client) getAclHTTP(endpoint url.URL) (*http.Response, error) {
 
 // https://docs.splunk.com/Documentation/Splunk/8.0.4/RESTUM/RESTusing#Access_Control_List
 func (client *Client) GetAcl(owner, app, name, sharing string, resources ...string) (*http.Response, error) {
-	resourcePath := []string{"servicesNS", owner, app}
-	resourcePath = append(resourcePath, resources...)
-	resourcePath = append(resourcePath, name, "acl")
-
 	var q url.Values
 	if strings.EqualFold(strings.TrimSpace(client.ACLGetMode), ACLGetModeCloud) {
 		q = url.Values{}
@@ -37,7 +33,7 @@ func (client *Client) GetAcl(owner, app, name, sharing string, resources ...stri
 			q.Set("sharing", sharing)
 		}
 	}
-	endpoint := client.BuildSplunkURL(q, resourcePath...)
+	endpoint := client.buildAclEndpoint(q, owner, app, name, resources...)
 	resp, err := client.getAclHTTP(endpoint)
 	if err != nil {
 		return nil, fmt.Errorf("GET failed for endpoint %s: %s", endpoint.Path, err)
@@ -74,10 +70,7 @@ func (client *Client) ResourcesAndNameForPath(path string) (resources []string, 
 }
 
 func (client *Client) UpdateAcl(owner, app, name string, acl *models.ACLObject, resources ...string) error {
-	resourcePath := []string{"servicesNS", owner, app}
-	resourcePath = append(resourcePath, resources...)
-	resourcePath = append(resourcePath, name, "acl")
-	endpoint := client.BuildSplunkURL(nil, resourcePath...)
+	endpoint := client.buildAclEndpoint(nil, owner, app, name, resources...)
 	isCloud := strings.EqualFold(strings.TrimSpace(client.ACLGetMode), ACLGetModeCloud)
 	readPerms := strings.Join(acl.Perms.Read, ",")
 	writePerms := strings.Join(acl.Perms.Write, ",")
@@ -130,6 +123,20 @@ func (client *Client) UpdateAcl(owner, app, name string, acl *models.ACLObject, 
 	}
 
 	return nil
+}
+
+func (client *Client) buildAclEndpoint(queryValues url.Values, owner, app, name string, resources ...string) url.URL {
+	resourcePath := []string{"servicesNS", owner, app}
+	resourcePath = append(resourcePath, resources...)
+	endpoint := client.BuildSplunkURLWithEscapedPathPart(queryValues, name, resourcePath...)
+	rawPath := endpoint.RawPath
+	if rawPath == "" {
+		rawPath = endpoint.EscapedPath()
+	}
+	endpoint.Path = appendURLPathPart(endpoint.Path, "acl")
+	endpoint.RawPath = appendURLPathPart(rawPath, "acl")
+
+	return endpoint
 }
 
 func (client *Client) Move(owner, app, name string, acl *models.ACLObject, resources ...string) error {

--- a/client/acl_test.go
+++ b/client/acl_test.go
@@ -6,6 +6,8 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/splunk/terraform-provider-splunk/client/models"
 )
 
 // TestGetAcl_CloudMode_QueryStringIncludesOwnerAndSharing verifies owner and sharing appear on the GET query when ACLGetMode is cloud.
@@ -93,5 +95,79 @@ func TestGetAcl_NonCloudMode_OmitsOwnerSharingFromQuery(t *testing.T) {
 	}
 	if q.Get("sharing") != "" {
 		t.Errorf("non-cloud mode should not set sharing query param, got %q", q.Get("sharing"))
+	}
+}
+
+func TestAclURLsEscapeResourceName(t *testing.T) {
+	t.Setenv(envVarHTTPScheme, "http")
+
+	acl := &models.ACLObject{
+		Sharing: "app",
+		Perms: models.Permissions{
+			Read:  []string{"*"},
+			Write: []string{"admin"},
+		},
+	}
+
+	tests := []struct {
+		name string
+		want string
+		call func(*Client) error
+	}{
+		{
+			name: "get saved search acl",
+			want: "/servicesNS/nobody/app/saved/searches/A%2FB+C%20D/acl",
+			call: func(c *Client) error {
+				resp, err := c.GetAcl("nobody", "app", "A/B+C D", "app", "saved", "searches")
+				if resp != nil {
+					defer resp.Body.Close()
+				}
+				return err
+			},
+		},
+		{
+			name: "update saved search acl",
+			want: "/servicesNS/nobody/app/saved/searches/A%2FB+C%20D/acl",
+			call: func(c *Client) error {
+				return c.UpdateAcl("nobody", "app", "A/B+C D", acl, "saved", "searches")
+			},
+		},
+		{
+			name: "update dashboard view acl",
+			want: "/servicesNS/nobody/app/data/ui/views/A%2FB+C%20D/acl",
+			call: func(c *Client) error {
+				return c.UpdateAcl("nobody", "app", "A/B+C D", acl, "data", "ui", "views")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				got = r.URL.EscapedPath()
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{}`))
+			}))
+			defer server.Close()
+
+			backend, err := url.Parse(server.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			client, err := NewSplunkdClient("", defaultAuth, backend.Host, "", server.Client())
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if err := tt.call(client); err != nil {
+				t.Fatalf("ACL call failed: %s", err)
+			}
+
+			if got != tt.want {
+				t.Errorf("escaped path invalid, got %s, want %s", got, tt.want)
+			}
+		})
 	}
 }

--- a/client/client.go
+++ b/client/client.go
@@ -100,6 +100,26 @@ func (c *Client) BuildSplunkURL(queryValues url.Values, urlPathParts ...string) 
 	}
 }
 
+func (c *Client) BuildSplunkURLWithEscapedPathPart(queryValues url.Values, pathPart string, urlPathParts ...string) url.URL {
+	endpoint := c.BuildSplunkURL(queryValues, urlPathParts...)
+	rawPath := endpoint.RawPath
+	if rawPath == "" {
+		rawPath = endpoint.EscapedPath()
+	}
+
+	endpoint.Path = appendURLPathPart(endpoint.Path, pathPart)
+	endpoint.RawPath = appendURLPathPart(rawPath, url.PathEscape(pathPart))
+
+	return endpoint
+}
+
+func appendURLPathPart(basePath, pathPart string) string {
+	if basePath == "" {
+		return pathPart
+	}
+	return strings.TrimRight(basePath, "/") + "/" + pathPart
+}
+
 // Do sends out request and returns HTTP response
 func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	response, err := c.httpClient.Do(req)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -73,6 +73,79 @@ func TestBuildSplunkURLSpecialCharactersInSearch(t *testing.T) {
 	}
 }
 
+func TestBuildSplunkURLWithEscapedPathPart(t *testing.T) {
+	client, err := NewDefaultSplunkdClient()
+	if err != nil {
+		t.Error(err)
+	}
+	url := client.BuildSplunkURLWithEscapedPathPart(nil, "A/B+C D", "servicesNS", "nobody", "app", "saved", "searches")
+
+	if got, want := url.Path, "servicesNS/nobody/app/saved/searches/A/B+C D"; got != want {
+		t.Errorf("path invalid, got %s, want %s", got, want)
+	}
+	if got, want := url.EscapedPath(), "servicesNS/nobody/app/saved/searches/A%2FB+C%20D"; got != want {
+		t.Errorf("escaped path invalid, got %s, want %s", got, want)
+	}
+}
+
+func TestNamespacedResourceReadersEscapeFinalPathSegment(t *testing.T) {
+	os.Setenv(envVarHTTPScheme, "http")
+	defer os.Unsetenv(envVarHTTPScheme)
+
+	tests := []struct {
+		name string
+		want string
+		call func(*Client) (*http.Response, error)
+	}{
+		{
+			name: "saved search",
+			want: "/servicesNS/nobody/app/saved/searches/A%2FB+C%20D",
+			call: func(client *Client) (*http.Response, error) {
+				return client.ReadSavedSearches("A/B+C D", "nobody", "app")
+			},
+		},
+		{
+			name: "dashboard view",
+			want: "/servicesNS/nobody/app/data/ui/views/A%2FB+C%20D",
+			call: func(client *Client) (*http.Response, error) {
+				return client.ReadDashboardObject("A/B+C D", "nobody", "app")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				got = r.URL.EscapedPath()
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{}`))
+			}))
+			defer server.Close()
+
+			backend, err := url.Parse(server.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			client, err := NewSplunkdClient("", defaultAuth, backend.Host, "", server.Client())
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			resp, err := tt.call(client)
+			if err != nil {
+				t.Fatalf("reader call failed: %s", err)
+			}
+			defer resp.Body.Close()
+
+			if got != tt.want {
+				t.Errorf("escaped path invalid, got %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestBuildSplunkURLNoHost(t *testing.T) {
 	client, err := NewDefaultSplunkdClient()
 	if err != nil {

--- a/client/data_ui_views.go
+++ b/client/data_ui_views.go
@@ -24,7 +24,7 @@ func (client *Client) CreateDashboardObject(owner string, app string, splunkDash
 }
 
 func (client *Client) ReadDashboardObject(name, owner, app string) (*http.Response, error) {
-	endpoint := client.BuildSplunkURL(nil, "servicesNS", owner, app, "data", "ui", "views", name)
+	endpoint := client.BuildSplunkURLWithEscapedPathPart(nil, name, "servicesNS", owner, app, "data", "ui", "views")
 	resp, err := client.Get(endpoint)
 	if err != nil {
 		return nil, err
@@ -39,7 +39,7 @@ func (client *Client) UpdateDashboardObject(owner string, app string, name strin
 	if err != nil {
 		return err
 	}
-	endpoint := client.BuildSplunkURL(nil, "servicesNS", owner, app, "data", "ui", "views", name)
+	endpoint := client.BuildSplunkURLWithEscapedPathPart(nil, name, "servicesNS", owner, app, "data", "ui", "views")
 	resp, err := client.Post(endpoint, values)
 	if err != nil {
 		return err
@@ -50,7 +50,7 @@ func (client *Client) UpdateDashboardObject(owner string, app string, name strin
 }
 
 func (client *Client) DeleteDashboardObject(owner string, app string, name string) (*http.Response, error) {
-	endpoint := client.BuildSplunkURL(nil, "servicesNS", owner, app, "data", "ui", "views", name)
+	endpoint := client.BuildSplunkURLWithEscapedPathPart(nil, name, "servicesNS", owner, app, "data", "ui", "views")
 	resp, err := client.Delete(endpoint)
 	if err != nil {
 		return nil, err

--- a/client/saved_searches.go
+++ b/client/saved_searches.go
@@ -33,7 +33,7 @@ func (client *Client) CreateSavedSearches(name, owner, app string, savedSearchOb
 }
 
 func (client *Client) ReadSavedSearches(name, owner, app string) (*http.Response, error) {
-	endpoint := client.BuildSplunkURL(nil, "servicesNS", owner, app, "saved", "searches", name)
+	endpoint := client.BuildSplunkURLWithEscapedPathPart(nil, name, "servicesNS", owner, app, "saved", "searches")
 	resp, err := client.Get(endpoint)
 	if err != nil {
 		return nil, err
@@ -47,7 +47,7 @@ func (client *Client) UpdateSavedSearches(name string, owner string, app string,
 	if err != nil {
 		return err
 	}
-	endpoint := client.BuildSplunkURL(nil, "servicesNS", owner, app, "saved", "searches", name)
+	endpoint := client.BuildSplunkURLWithEscapedPathPart(nil, name, "servicesNS", owner, app, "saved", "searches")
 	resp, err := client.Post(endpoint, values)
 	if err != nil {
 		return err
@@ -57,7 +57,7 @@ func (client *Client) UpdateSavedSearches(name string, owner string, app string,
 }
 
 func (client *Client) DeleteSavedSearches(name, owner, app string) (*http.Response, error) {
-	endpoint := client.BuildSplunkURL(nil, "servicesNS", owner, app, "saved", "searches", name)
+	endpoint := client.BuildSplunkURLWithEscapedPathPart(nil, name, "servicesNS", owner, app, "saved", "searches")
 	resp, err := client.Delete(endpoint)
 	if err != nil {
 		return nil, err

--- a/docs/resources/data_ui_views.md
+++ b/docs/resources/data_ui_views.md
@@ -24,3 +24,17 @@ This resource block supports the following arguments:
 In addition to all arguments above, This resource block exports the following arguments:
 
 * `id` - The ID of the dashboard
+
+## Import
+
+Dashboards/views in the default namespace can be imported by name:
+
+```
+terraform import splunk_data_ui_views.example "<view-name>"
+```
+
+Dashboards/views in a specific Splunk namespace can be imported with a Splunk REST path or URL. URL-encode the view name when it contains spaces or other special characters:
+
+```
+terraform import splunk_data_ui_views.example "/servicesNS/<owner>/<app>/data/ui/views/<url-encoded-view-name>"
+```

--- a/docs/resources/saved_searches.md
+++ b/docs/resources/saved_searches.md
@@ -225,3 +225,17 @@ This resource block supports the following arguments:
 In addition to all arguments above, This resource block exports the following arguments:
 
 - `id` - The ID of the saved search resource
+
+## Import
+
+Saved searches in the default namespace can be imported by name:
+
+```
+terraform import splunk_saved_searches.example "<saved-search-name>"
+```
+
+Saved searches in a specific Splunk namespace can be imported with a Splunk REST path or URL. URL-encode the saved search name when it contains spaces or other special characters:
+
+```
+terraform import splunk_saved_searches.example "/servicesNS/<owner>/<app>/saved/searches/<url-encoded-saved-search-name>"
+```

--- a/splunk/namespaced_import.go
+++ b/splunk/namespaced_import.go
@@ -1,0 +1,127 @@
+package splunk
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/splunk/terraform-provider-splunk/client/models"
+)
+
+type namespacedRESTImportID struct {
+	Owner string
+	App   string
+	Name  string
+}
+
+func parseNamespacedRESTImportID(id string, resourceParts ...string) (*namespacedRESTImportID, bool, error) {
+	rawPath, isPathImport := importIDPath(id)
+	if !isPathImport {
+		return nil, false, nil
+	}
+	pathParts := strings.Split(strings.Trim(rawPath, "/"), "/")
+
+	servicesNSIndex := -1
+	for i, part := range pathParts {
+		if part == "servicesNS" {
+			servicesNSIndex = i
+			break
+		}
+	}
+	if servicesNSIndex == -1 {
+		return nil, false, nil
+	}
+
+	pathParts = pathParts[servicesNSIndex:]
+	minParts := 3 + len(resourceParts) + 1
+	if len(pathParts) != minParts {
+		return nil, true, fmt.Errorf("import path must be /servicesNS/<owner>/<app>/%s/<name>", strings.Join(resourceParts, "/"))
+	}
+
+	owner, err := decodeImportPathSegment(pathParts[1])
+	if err != nil {
+		return nil, true, fmt.Errorf("unable to decode owner in import path: %w", err)
+	}
+	app, err := decodeImportPathSegment(pathParts[2])
+	if err != nil {
+		return nil, true, fmt.Errorf("unable to decode app in import path: %w", err)
+	}
+
+	for i, expected := range resourceParts {
+		actual, err := decodeImportPathSegment(pathParts[3+i])
+		if err != nil {
+			return nil, true, fmt.Errorf("unable to decode resource path in import path: %w", err)
+		}
+		if actual != expected {
+			return nil, true, fmt.Errorf("import path must be /servicesNS/<owner>/<app>/%s/<name>", strings.Join(resourceParts, "/"))
+		}
+	}
+
+	name, err := decodeImportPathSegment(pathParts[3+len(resourceParts)])
+	if err != nil {
+		return nil, true, fmt.Errorf("unable to decode resource name in import path: %w", err)
+	}
+	if owner == "" || app == "" || name == "" {
+		return nil, true, fmt.Errorf("import path must include non-empty owner, app, and name")
+	}
+
+	return &namespacedRESTImportID{Owner: owner, App: app, Name: name}, true, nil
+}
+
+func importIDPath(id string) (string, bool) {
+	trimmed := strings.TrimSpace(id)
+	parsed, err := url.Parse(trimmed)
+	if err == nil && (parsed.Scheme != "" || parsed.Host != "") {
+		if parsed.RawPath != "" {
+			return parsed.RawPath, true
+		}
+		if escapedPath := parsed.EscapedPath(); escapedPath != "" {
+			return escapedPath, true
+		}
+		return parsed.Path, true
+	}
+
+	if !strings.HasPrefix(trimmed, "/") {
+		return "", false
+	}
+
+	if i := strings.IndexAny(trimmed, "?#"); i >= 0 {
+		return trimmed[:i], true
+	}
+	return trimmed, true
+}
+
+func decodeImportPathSegment(segment string) (string, error) {
+	return url.PathUnescape(segment)
+}
+
+func importNamespacedResourceState(d *schema.ResourceData, resourceParts ...string) (bool, error) {
+	parsed, matched, err := parseNamespacedRESTImportID(d.Id(), resourceParts...)
+	if err != nil || !matched {
+		return matched, err
+	}
+
+	d.SetId(parsed.Name)
+	if err := d.Set("name", parsed.Name); err != nil {
+		return true, err
+	}
+
+	aclObject := &models.ACLObject{
+		Owner:   parsed.Owner,
+		App:     parsed.App,
+		Sharing: inferredNamespacedImportSharing(parsed.Owner),
+	}
+	if err := d.Set("acl", flattenACL(aclObject)); err != nil {
+		return true, err
+	}
+
+	return true, nil
+}
+
+func inferredNamespacedImportSharing(owner string) string {
+	if owner == "nobody" {
+		return "app"
+	}
+	return "user"
+}

--- a/splunk/namespaced_import_test.go
+++ b/splunk/namespaced_import_test.go
@@ -1,0 +1,213 @@
+package splunk
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func TestParseNamespacedRESTImportID(t *testing.T) {
+	tests := []struct {
+		name          string
+		id            string
+		resourceParts []string
+		wantMatched   bool
+		wantOwner     string
+		wantApp       string
+		wantName      string
+		wantErr       bool
+	}{
+		{
+			name:          "saved search path",
+			id:            "/servicesNS/nobody/<app>/saved/searches/Example%20Saved%20Search",
+			resourceParts: []string{"saved", "searches"},
+			wantMatched:   true,
+			wantOwner:     "nobody",
+			wantApp:       "<app>",
+			wantName:      "Example Saved Search",
+		},
+		{
+			name:          "view full url",
+			id:            "https://example.invalid:8089/servicesNS/<owner>/<app>/data/ui/views/Example%20View?output_mode=json",
+			resourceParts: []string{"data", "ui", "views"},
+			wantMatched:   true,
+			wantOwner:     "<owner>",
+			wantApp:       "<app>",
+			wantName:      "Example View",
+		},
+		{
+			name:          "literal plus remains plus",
+			id:            "/servicesNS/nobody/<app>/saved/searches/Example+Saved+Search",
+			resourceParts: []string{"saved", "searches"},
+			wantMatched:   true,
+			wantOwner:     "nobody",
+			wantApp:       "<app>",
+			wantName:      "Example+Saved+Search",
+		},
+		{
+			name:          "encoded plus remains plus",
+			id:            "/servicesNS/nobody/<app>/saved/searches/Example%2BSaved%2BSearch",
+			resourceParts: []string{"saved", "searches"},
+			wantMatched:   true,
+			wantOwner:     "nobody",
+			wantApp:       "<app>",
+			wantName:      "Example+Saved+Search",
+		},
+		{
+			name:          "full url encoded plus remains plus",
+			id:            "https://example.invalid:8089/servicesNS/nobody/<app>/saved/searches/Example%2BSaved%2BSearch",
+			resourceParts: []string{"saved", "searches"},
+			wantMatched:   true,
+			wantOwner:     "nobody",
+			wantApp:       "<app>",
+			wantName:      "Example+Saved+Search",
+		},
+		{
+			name:          "encoded slash remains in name",
+			id:            "/servicesNS/nobody/<app>/saved/searches/Example%2FSaved%20Search",
+			resourceParts: []string{"saved", "searches"},
+			wantMatched:   true,
+			wantOwner:     "nobody",
+			wantApp:       "<app>",
+			wantName:      "Example/Saved Search",
+		},
+		{
+			name:          "bare name falls back to legacy import",
+			id:            "Example Saved Search",
+			resourceParts: []string{"saved", "searches"},
+			wantMatched:   false,
+		},
+		{
+			name:          "bare servicesNS name falls back to legacy import",
+			id:            "servicesNS",
+			resourceParts: []string{"saved", "searches"},
+			wantMatched:   false,
+		},
+		{
+			name:          "relative servicesNS path falls back to legacy import",
+			id:            "prefix/servicesNS/nobody/<app>/saved/searches/Example%20Saved%20Search",
+			resourceParts: []string{"saved", "searches"},
+			wantMatched:   false,
+		},
+		{
+			name:          "wrong resource path errors",
+			id:            "/servicesNS/nobody/<app>/data/ui/views/Example%20Saved%20Search",
+			resourceParts: []string{"saved", "searches"},
+			wantMatched:   true,
+			wantErr:       true,
+		},
+		{
+			name:          "child endpoint errors",
+			id:            "/servicesNS/nobody/<app>/saved/searches/Example%20Saved%20Search/acl",
+			resourceParts: []string{"saved", "searches"},
+			wantMatched:   true,
+			wantErr:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, matched, err := parseNamespacedRESTImportID(tt.id, tt.resourceParts...)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if matched != tt.wantMatched {
+				t.Fatalf("matched = %v, want %v", matched, tt.wantMatched)
+			}
+			if !matched {
+				return
+			}
+			if got.Owner != tt.wantOwner {
+				t.Errorf("owner = %q, want %q", got.Owner, tt.wantOwner)
+			}
+			if got.App != tt.wantApp {
+				t.Errorf("app = %q, want %q", got.App, tt.wantApp)
+			}
+			if got.Name != tt.wantName {
+				t.Errorf("name = %q, want %q", got.Name, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestSavedSearchesImportStateNamespacedPath(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, savedSearches().Schema, nil)
+	d.SetId("/servicesNS/nobody/<app>/saved/searches/Example%20Saved%20Search")
+
+	states, err := savedSearchesImportState(d, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if len(states) != 1 {
+		t.Fatalf("state count = %d, want 1", len(states))
+	}
+	if got, want := d.Id(), "Example Saved Search"; got != want {
+		t.Fatalf("id = %q, want %q", got, want)
+	}
+	if got, want := d.Get("name").(string), "Example Saved Search"; got != want {
+		t.Fatalf("name = %q, want %q", got, want)
+	}
+
+	acl := getACLConfig(d.Get("acl").([]interface{}))
+	if got, want := acl.Owner, "nobody"; got != want {
+		t.Errorf("acl owner = %q, want %q", got, want)
+	}
+	if got, want := acl.App, "<app>"; got != want {
+		t.Errorf("acl app = %q, want %q", got, want)
+	}
+	if got, want := acl.Sharing, "app"; got != want {
+		t.Errorf("acl sharing = %q, want %q", got, want)
+	}
+}
+
+func TestSavedSearchesImportStateBareName(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, savedSearches().Schema, nil)
+	d.SetId("Example Saved Search")
+
+	_, err := savedSearchesImportState(d, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if got, want := d.Id(), "Example Saved Search"; got != want {
+		t.Fatalf("id = %q, want %q", got, want)
+	}
+	if got, want := d.Get("name").(string), "Example Saved Search"; got != want {
+		t.Fatalf("name = %q, want %q", got, want)
+	}
+}
+
+func TestSplunkDashboardsImportStateNamespacedURL(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, splunkDashboards().Schema, nil)
+	d.SetId("https://example.invalid:8089/servicesNS/<owner>/<app>/data/ui/views/Example%20View?output_mode=json")
+
+	states, err := splunkDashboardsImportState(d, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if len(states) != 1 {
+		t.Fatalf("state count = %d, want 1", len(states))
+	}
+	if got, want := d.Id(), "Example View"; got != want {
+		t.Fatalf("id = %q, want %q", got, want)
+	}
+	if got, want := d.Get("name").(string), "Example View"; got != want {
+		t.Fatalf("name = %q, want %q", got, want)
+	}
+
+	acl := getACLConfig(d.Get("acl").([]interface{}))
+	if got, want := acl.Owner, "<owner>"; got != want {
+		t.Errorf("acl owner = %q, want %q", got, want)
+	}
+	if got, want := acl.App, "<app>"; got != want {
+		t.Errorf("acl app = %q, want %q", got, want)
+	}
+	if got, want := acl.Sharing, "user"; got != want {
+		t.Errorf("acl sharing = %q, want %q", got, want)
+	}
+}

--- a/splunk/resource_splunk_data_ui_views.go
+++ b/splunk/resource_splunk_data_ui_views.go
@@ -36,9 +36,23 @@ func splunkDashboards() *schema.Resource {
 		Delete: splunkDashboardsDelete,
 		Update: splunkDashboardsUpdate,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: splunkDashboardsImportState,
 		},
 	}
+}
+
+func splunkDashboardsImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	imported, err := importNamespacedResourceState(d, "data", "ui", "views")
+	if err != nil {
+		return nil, err
+	}
+	if !imported {
+		if err := d.Set("name", d.Id()); err != nil {
+			return nil, err
+		}
+	}
+
+	return []*schema.ResourceData{d}, nil
 }
 
 // Functions

--- a/splunk/resource_splunk_saved_searches.go
+++ b/splunk/resource_splunk_saved_searches.go
@@ -1263,10 +1263,24 @@ func savedSearches() *schema.Resource {
 		Update: savedSearchesUpdate,
 		Delete: savedSearchesDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: savedSearchesImportState,
 		},
 	}
 
+}
+
+func savedSearchesImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	imported, err := importNamespacedResourceState(d, "saved", "searches")
+	if err != nil {
+		return nil, err
+	}
+	if !imported {
+		if err := d.Set("name", d.Id()); err != nil {
+			return nil, err
+		}
+	}
+
+	return []*schema.ResourceData{d}, nil
 }
 
 func resourceAlertTrackV0() *schema.Resource {


### PR DESCRIPTION
Summary
- Support importing saved searches and data UI views from Splunk REST paths or URLs with owner/app namespace.
- Preserve existing bare-name imports.
- Document REST path import examples with placeholders only.

Fixes #179.