### PR TITLE
DW-10738: Scope configs_conf reads to ACL namespace

### DIFF
--- a/docs/resources/configs_conf.md
+++ b/docs/resources/configs_conf.md
@@ -20,9 +20,29 @@ This resource block supports the following arguments:
 * `variables` - (Optional) A map of key value pairs for a stanza.
 * `acl` - (Optional) The app/user context that is the namespace for the resource
 
+During refresh, the provider reads the stanza through the configured `acl`
+namespace. Configure `acl` when the same configuration and stanza name exists
+in more than one app or owner namespace.
+
 **NOTE:** When importing an existing conf file, Splunk will respond with all default values for the conf file stanza (even if they do not appear explicitly in the stanza itself). These can be added to the associated `configs_conf` Terraform resource in your `.tf` file, otherwise they will show up as removed in the `terraform plan` diff. <b>Although the plan will show them being removed, these default fields will <b>not</b> actually be modified or removed by Splunk.</b>
 
 ## Attribute Reference
 In addition to all arguments above, This resource block exports the following arguments:
 
 * `id` - The ID of the resource
+
+## Import
+
+Configuration stanzas in the default `nobody/search` namespace can be imported
+by configuration and stanza name:
+
+```
+terraform import splunk_configs_conf.example "<configuration>/<stanza>"
+```
+
+Configuration stanzas in a specific Splunk namespace can be imported with a
+Splunk REST path or URL. URL-encode the stanza as one path segment when needed:
+
+```
+terraform import splunk_configs_conf.example "/servicesNS/<owner>/<app>/configs/conf-<configuration>/<url-encoded-stanza>"
+```

--- a/splunk/namespaced_import.go
+++ b/splunk/namespaced_import.go
@@ -69,6 +69,67 @@ func parseNamespacedRESTImportID(id string, resourceParts ...string) (*namespace
 	return &namespacedRESTImportID{Owner: owner, App: app, Name: name}, true, nil
 }
 
+func parseNamespacedConfigsConfImportID(id string) (*namespacedRESTImportID, bool, error) {
+	rawPath, isPathImport := importIDPath(id)
+	if !isPathImport {
+		return nil, false, nil
+	}
+	pathParts := strings.Split(strings.Trim(rawPath, "/"), "/")
+
+	servicesNSIndex := -1
+	for i, part := range pathParts {
+		if part == "servicesNS" {
+			servicesNSIndex = i
+			break
+		}
+	}
+	if servicesNSIndex == -1 {
+		return nil, false, nil
+	}
+
+	pathParts = pathParts[servicesNSIndex:]
+	const expectedParts = 6
+	const expectedPath = "/servicesNS/<owner>/<app>/configs/conf-<configuration>/<stanza>"
+	if len(pathParts) != expectedParts {
+		return nil, true, fmt.Errorf("import path must be %s", expectedPath)
+	}
+
+	owner, err := decodeImportPathSegment(pathParts[1])
+	if err != nil {
+		return nil, true, fmt.Errorf("unable to decode owner in import path: %w", err)
+	}
+	app, err := decodeImportPathSegment(pathParts[2])
+	if err != nil {
+		return nil, true, fmt.Errorf("unable to decode app in import path: %w", err)
+	}
+	resource, err := decodeImportPathSegment(pathParts[3])
+	if err != nil {
+		return nil, true, fmt.Errorf("unable to decode resource path in import path: %w", err)
+	}
+	confPart, err := decodeImportPathSegment(pathParts[4])
+	if err != nil {
+		return nil, true, fmt.Errorf("unable to decode configuration in import path: %w", err)
+	}
+	stanza, err := decodeImportPathSegment(pathParts[5])
+	if err != nil {
+		return nil, true, fmt.Errorf("unable to decode stanza in import path: %w", err)
+	}
+
+	if resource != "configs" || !strings.HasPrefix(confPart, "conf-") {
+		return nil, true, fmt.Errorf("import path must be %s", expectedPath)
+	}
+	conf := strings.TrimPrefix(confPart, "conf-")
+	if owner == "" || app == "" || conf == "" || stanza == "" {
+		return nil, true, fmt.Errorf("import path must include non-empty owner, app, configuration, and stanza")
+	}
+
+	return &namespacedRESTImportID{
+		Owner: owner,
+		App:   app,
+		Name:  conf + "/" + stanza,
+	}, true, nil
+}
+
 func importIDPath(id string) (string, bool) {
 	trimmed := strings.TrimSpace(id)
 	parsed, err := url.Parse(trimmed)

--- a/splunk/namespaced_import_test.go
+++ b/splunk/namespaced_import_test.go
@@ -136,6 +136,128 @@ func TestParseNamespacedRESTImportID(t *testing.T) {
 	}
 }
 
+func TestParseNamespacedConfigsConfImportID(t *testing.T) {
+	tests := []struct {
+		name        string
+		id          string
+		wantMatched bool
+		wantOwner   string
+		wantApp     string
+		wantName    string
+		wantErr     bool
+	}{
+		{
+			name:        "configs conf path",
+			id:          "/servicesNS/nobody/search_app_dashweb/configs/conf-props/httpevent",
+			wantMatched: true,
+			wantOwner:   "nobody",
+			wantApp:     "search_app_dashweb",
+			wantName:    "props/httpevent",
+		},
+		{
+			name:        "configs conf full url with encoded stanza",
+			id:          "https://example.invalid:8089/servicesNS/admin/search/configs/conf-inputs/sqs%3Aqueue",
+			wantMatched: true,
+			wantOwner:   "admin",
+			wantApp:     "search",
+			wantName:    "inputs/sqs:queue",
+		},
+		{
+			name:        "bare name falls back to default namespace import",
+			id:          "props/httpevent",
+			wantMatched: false,
+		},
+		{
+			name:        "wrong resource path errors",
+			id:          "/servicesNS/nobody/search_app_dashweb/saved/conf-props/httpevent",
+			wantMatched: true,
+			wantErr:     true,
+		},
+		{
+			name:        "missing configuration prefix errors",
+			id:          "/servicesNS/nobody/search_app_dashweb/configs/props/httpevent",
+			wantMatched: true,
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, matched, err := parseNamespacedConfigsConfImportID(tt.id)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if matched != tt.wantMatched {
+				t.Fatalf("matched = %v, want %v", matched, tt.wantMatched)
+			}
+			if !matched {
+				return
+			}
+			if got.Owner != tt.wantOwner {
+				t.Errorf("owner = %q, want %q", got.Owner, tt.wantOwner)
+			}
+			if got.App != tt.wantApp {
+				t.Errorf("app = %q, want %q", got.App, tt.wantApp)
+			}
+			if got.Name != tt.wantName {
+				t.Errorf("name = %q, want %q", got.Name, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestConfigsConfImportStateNamespacedPath(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, configsConf().Schema, nil)
+	d.SetId("/servicesNS/nobody/search_app_dashweb/configs/conf-props/httpevent")
+
+	states, err := configsConfImportState(d, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if len(states) != 1 {
+		t.Fatalf("state count = %d, want 1", len(states))
+	}
+	if got, want := d.Id(), "props/httpevent"; got != want {
+		t.Fatalf("id = %q, want %q", got, want)
+	}
+	if got, want := d.Get("name").(string), "props/httpevent"; got != want {
+		t.Fatalf("name = %q, want %q", got, want)
+	}
+
+	acl := getACLConfig(d.Get("acl").([]interface{}))
+	if got, want := acl.Owner, "nobody"; got != want {
+		t.Errorf("acl owner = %q, want %q", got, want)
+	}
+	if got, want := acl.App, "search_app_dashweb"; got != want {
+		t.Errorf("acl app = %q, want %q", got, want)
+	}
+	if got, want := acl.Sharing, "app"; got != want {
+		t.Errorf("acl sharing = %q, want %q", got, want)
+	}
+}
+
+func TestConfigsConfImportStateBareName(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, configsConf().Schema, nil)
+	d.SetId("props/httpevent")
+
+	_, err := configsConfImportState(d, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if got, want := d.Id(), "props/httpevent"; got != want {
+		t.Fatalf("id = %q, want %q", got, want)
+	}
+	if got, want := d.Get("name").(string), "props/httpevent"; got != want {
+		t.Fatalf("name = %q, want %q", got, want)
+	}
+}
+
 func TestSavedSearchesImportStateNamespacedPath(t *testing.T) {
 	d := schema.TestResourceDataRaw(t, savedSearches().Schema, nil)
 	d.SetId("/servicesNS/nobody/<app>/saved/searches/Example%20Saved%20Search")

--- a/splunk/resource_splunk_configs_conf.go
+++ b/splunk/resource_splunk_configs_conf.go
@@ -44,9 +44,34 @@ func configsConf() *schema.Resource {
 		Delete: configsConfDelete,
 		Update: configsConfUpdate,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: configsConfImportState,
 		},
 	}
+}
+
+func configsConfImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	parsed, matched, err := parseNamespacedConfigsConfImportID(d.Id())
+	if err != nil {
+		return nil, err
+	}
+	if matched {
+		d.SetId(parsed.Name)
+		if err := d.Set("name", parsed.Name); err != nil {
+			return nil, err
+		}
+		aclObject := &models.ACLObject{
+			Owner:   parsed.Owner,
+			App:     parsed.App,
+			Sharing: inferredNamespacedImportSharing(parsed.Owner),
+		}
+		if err := d.Set("acl", flattenACL(aclObject)); err != nil {
+			return nil, err
+		}
+	} else if err := d.Set("name", d.Id()); err != nil {
+		return nil, err
+	}
+
+	return []*schema.ResourceData{d}, nil
 }
 
 // Functions
@@ -90,15 +115,20 @@ func configsConfCreate(d *schema.ResourceData, meta interface{}) error {
 
 func configsConfRead(d *schema.ResourceData, meta interface{}) error {
 	provider := meta.(*SplunkProvider)
-	name := d.Id()
+	name := d.Get("name").(string)
+	if name == "" {
+		name = d.Id()
+	}
 	_, stanza := (*provider.Client).SplitConfStanza(name)
+	aclObject := getResourceDataConfigsConfACL(d)
 
-	// We first get list of stanzas in a conf file to get owner and app name for the specific stanza
-	resp, err := (*provider.Client).ReadAllConfigsConfObject(name)
+	// Read through the resource's namespace. A conf file can contain the same
+	// stanza name in multiple app and owner namespaces.
+	resp, err := (*provider.Client).ReadConfigsConfObject(name, aclObject.Owner, aclObject.App)
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	entry, err := getConfigsConfConfigByName(stanza, resp)
 	if err != nil {
@@ -109,18 +139,11 @@ func configsConfRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Unable to find resource: %v", name)
 	}
 
-	// Now we read the input configuration with proper owner and app
-	resp, err = (*provider.Client).ReadConfigsConfObject(name, entry.ACL.Owner, entry.ACL.App)
+	contentResp, err := (*provider.Client).ReadConfigsConfObject(name, aclObject.Owner, aclObject.App)
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
-
-	contentResp, err := (*provider.Client).ReadConfigsConfObject(name, entry.ACL.Owner, entry.ACL.App)
-	if err != nil {
-		return err
-	}
-	defer contentResp.Body.Close()
+	defer func() { _ = contentResp.Body.Close() }()
 
 	var result map[string]interface{}
 	b, _ := io.ReadAll(contentResp.Body)
@@ -142,12 +165,7 @@ func configsConfRead(d *schema.ResourceData, meta interface{}) error {
 	// Override value to convert bool Type to string
 	content["disabled"] = strconv.FormatBool(content["disabled"].(bool))
 
-	entry, err = getConfigsConfConfigByName(stanza, resp)
-	if err != nil {
-		return err
-	}
-
-	if err = d.Set("name", d.Id()); err != nil {
+	if err = d.Set("name", name); err != nil {
 		return err
 	}
 
@@ -227,6 +245,21 @@ func getConfigsConfConfig(d *schema.ResourceData) (configsConfConfigObject *mode
 	configsConfConfigObject.Variables = mapString
 
 	return configsConfConfigObject
+}
+
+func getResourceDataConfigsConfACL(d *schema.ResourceData) *models.ACLObject {
+	aclObject := &models.ACLObject{
+		Owner:   "nobody",
+		App:     "search",
+		Sharing: "app",
+	}
+	if r, ok := d.GetOk("acl"); ok {
+		aclObject = getACLConfig(r.([]interface{}))
+	}
+	if aclObject.Sharing != "user" {
+		aclObject.Owner = "nobody"
+	}
+	return aclObject
 }
 
 func getConfigsConfConfigByName(name string, httpResponse *http.Response) (configsConfEntry *models.ConfigsConfEntry, err error) {

--- a/splunk/resource_splunk_configs_conf_test.go
+++ b/splunk/resource_splunk_configs_conf_test.go
@@ -2,10 +2,15 @@ package splunk
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	splunkclient "github.com/splunk/terraform-provider-splunk/client"
 )
 
 const newConfigsConf = `
@@ -27,6 +32,139 @@ resource "splunk_configs_conf" "tftest-stanza" {
 	}
 }
 `
+
+func TestConfigsConfReadUsesConfiguredNamespace(t *testing.T) {
+	t.Setenv("HTTPScheme", "http")
+
+	var requestPaths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPaths = append(requestPaths, r.URL.EscapedPath())
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, `{
+			"entry": [{
+				"name": "httpevent",
+				"acl": {
+					"app": "search_app_dashweb",
+					"owner": "nobody",
+					"sharing": "app",
+					"perms": {"read": ["*"], "write": ["admin"]}
+				},
+				"content": {
+					"disabled": false,
+					"EXTRACT-environment": "environment=(?P<environment>[^ ]+)"
+				}
+			}],
+			"messages": []
+		}`)
+	}))
+	defer server.Close()
+
+	backend, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, err := splunkclient.NewSplunkdClient(
+		"",
+		[2]string{"admin", "password"},
+		backend.Host,
+		"",
+		server.Client(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	d := schema.TestResourceDataRaw(t, configsConf().Schema, map[string]interface{}{
+		"name": "props/httpevent",
+		"acl": []interface{}{map[string]interface{}{
+			"owner":   "nobody",
+			"app":     "search_app_dashweb",
+			"sharing": "app",
+		}},
+	})
+	d.SetId("props/httpevent")
+
+	if err := configsConfRead(d, &SplunkProvider{Client: client}); err != nil {
+		t.Fatalf("configsConfRead: %v", err)
+	}
+
+	const expectedPath = "/servicesNS/nobody/search_app_dashweb/configs/conf-props/httpevent"
+	if len(requestPaths) == 0 {
+		t.Fatal("expected at least one request")
+	}
+	for _, got := range requestPaths {
+		if got != expectedPath {
+			t.Errorf("request path = %q, want %q", got, expectedPath)
+		}
+	}
+
+	acl := getACLConfig(d.Get("acl").([]interface{}))
+	if got, want := acl.App, "search_app_dashweb"; got != want {
+		t.Errorf("acl app = %q, want %q", got, want)
+	}
+	if got, want := acl.Owner, "nobody"; got != want {
+		t.Errorf("acl owner = %q, want %q", got, want)
+	}
+}
+
+func TestGetResourceDataConfigsConfACL(t *testing.T) {
+	tests := []struct {
+		name        string
+		raw         map[string]interface{}
+		wantOwner   string
+		wantApp     string
+		wantSharing string
+	}{
+		{
+			name:        "default namespace",
+			wantOwner:   "nobody",
+			wantApp:     "search",
+			wantSharing: "app",
+		},
+		{
+			name: "app shared namespace uses nobody",
+			raw: map[string]interface{}{
+				"acl": []interface{}{map[string]interface{}{
+					"owner":   "admin",
+					"app":     "custom_app",
+					"sharing": "app",
+				}},
+			},
+			wantOwner:   "nobody",
+			wantApp:     "custom_app",
+			wantSharing: "app",
+		},
+		{
+			name: "user shared namespace keeps owner",
+			raw: map[string]interface{}{
+				"acl": []interface{}{map[string]interface{}{
+					"owner":   "alice",
+					"app":     "custom_app",
+					"sharing": "user",
+				}},
+			},
+			wantOwner:   "alice",
+			wantApp:     "custom_app",
+			wantSharing: "user",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := schema.TestResourceDataRaw(t, configsConf().Schema, tt.raw)
+			got := getResourceDataConfigsConfACL(d)
+			if got.Owner != tt.wantOwner {
+				t.Errorf("owner = %q, want %q", got.Owner, tt.wantOwner)
+			}
+			if got.App != tt.wantApp {
+				t.Errorf("app = %q, want %q", got.App, tt.wantApp)
+			}
+			if got.Sharing != tt.wantSharing {
+				t.Errorf("sharing = %q, want %q", got.Sharing, tt.wantSharing)
+			}
+		})
+	}
+}
 
 func TestAccCreateSplunkConfigsConf(t *testing.T) {
 	resourceName := "splunk_configs_conf.tftest-stanza"
@@ -111,7 +249,6 @@ func TestAccCreateSplunkConfigsConfSpecialChars(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccSplunkConfigsConfDestroyResources(s *terraform.State) error {
 	client, err := newTestClient()


### PR DESCRIPTION
## Summary

Scopes `splunk_configs_conf` refreshes to the resource's ACL namespace. The provider now reads the configured stanza through `/servicesNS/<owner>/<app>/configs/conf-<configuration>/<stanza>` instead of listing every visible stanza and selecting the first matching name.

This also adds namespaced REST-path imports for configuration stanzas. Bare `<configuration>/<stanza>` imports continue to target the default `nobody/search` namespace.

## Problem

`splunk_configs_conf` stores an ID such as `props/httpevent`. The previous read path called `/servicesNS/-/-/configs/conf-props`, then selected the first entry named `httpevent`.

Splunk can contain the same configuration and stanza name in several app or user namespaces. When API ordering returns another namespace first, refresh overwrites the resource's ACL state. Terraform can then propose replacing the configured object because `acl.app` and `acl.sharing` are `ForceNew` fields.

For example, this resource should always read the `nobody/search_app_dashweb` object:

```hcl
resource "splunk_configs_conf" "example" {
  name = "props/httpevent"

  acl {
    owner   = "nobody"
    app     = "search_app_dashweb"
    sharing = "app"
  }
}
```

## Behavior after this change

- App-shared and globally shared stanzas are read through `nobody/<app>`.
- User-shared stanzas are read through `<owner>/<app>`.
- Resources without an `acl` block use the existing `nobody/search` defaults.
- Existing state IDs remain `<configuration>/<stanza>`.
- Non-default objects can be imported with `/servicesNS/<owner>/<app>/configs/conf-<configuration>/<stanza>` or the equivalent full URL.

State that already contains the intended ACL needs no migration. If an earlier ambiguous refresh already stored another namespace's ACL, re-import the intended object with the namespaced REST path.

## Tests

- `make test`: passed
- `make build`: passed
- `go test -race ./...`: passed
- `go vet ./...`: passed
- Focused tests verify exact namespace reads, default/app/user ACL behavior, namespaced path and URL parsing, legacy imports, and malformed import paths
- `golangci-lint run ./...`: reports 12 existing issues outside the changed files; the changed files add no lint findings
- `terraform fmt -check -recursive`: reports the existing formatting difference in `examples/splunk/saved_search_email_include/main.tf`, which this PR does not modify

The repository's hosted workflow will run the acceptance suite against its Splunk service.

## Backout

Revert this commit to restore the global list-and-match read behavior. The change does not alter the Terraform state ID format.
